### PR TITLE
Change field type to password on Installer form

### DIFF
--- a/src/Installer/Form/ApigeeDemoInstallerForm.php
+++ b/src/Installer/Form/ApigeeDemoInstallerForm.php
@@ -81,7 +81,7 @@ class ApigeeDemoInstallerForm extends FormBase {
       '#maxlength' => 128,
     ];
     $form['password'] = [
-      '#type' => 'textfield',
+      '#type' => 'password',
       '#title' => $this->t('Password'),
       '#size' => 60,
       '#maxlength' => 128,


### PR DESCRIPTION
Currently the password field on the ApigeeDemoInstallerForm is the textfield.. Let's have the password field so that the entered password will not be visible during installation..