### PR TITLE
DRUP-530 Add swagger formatter for API Docs

### DIFF
--- a/apigee_devportal_kickstart.info.yml
+++ b/apigee_devportal_kickstart.info.yml
@@ -64,6 +64,7 @@ install:
 - forum
 - paragraphs
 - pathauto
+- swagger_ui_formatter
 
 # List any themes that should be installed as part of the profile installation.
 # Note that this will not set any theme as the default theme.

--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,26 @@
     "drupal": {
       "type": "composer",
       "url": "https://packages.drupal.org/8"
+    },
+    "swagger-api/swagger-ui":     {
+      "type": "package",
+      "package": {
+        "name": "swagger-api/swagger-ui",
+        "version": "3.22.0",
+        "type": "drupal-library",
+        "dist": {
+          "url": "https://github.com/swagger-api/swagger-ui/archive/v3.22.0.zip",
+          "type": "zip"
+        },
+        "require": {
+          "composer/installers": "^1.2.0"
+        }
+      }
     }
   },
   "require": {
     "php": "^7.1",
     "cweagans/composer-patches": "~1",
-    "slowprog/composer-copy-file": "~0.3",
     "drupal-composer/drupal-scaffold": "^2",
     "drupal/admin_toolbar": "^1.0",
     "drupal/adminimal_admin_toolbar": "^1.9",
@@ -41,11 +55,7 @@
   },
   "scripts": {
     "post-install-cmd": [
-      "@composer drupal-scaffold",
-      "SlowProg\\CopyFile\\ScriptHandler::copy"
-    ],
-    "post-update-cmd": [
-      "SlowProg\\CopyFile\\ScriptHandler::copy"
+      "@composer drupal-scaffold"
     ],
     "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold"
   },
@@ -70,9 +80,6 @@
         "type:drupal-theme"
       ]
     },
-    "enable-patching": true,
-    "copy-file": {
-      "vendor/swagger-api/swagger-ui/": "web/libraries/swagger_ui"
-    }
+    "enable-patching": true
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
   "require": {
     "php": "^7.1",
     "cweagans/composer-patches": "~1",
+    "slowprog/composer-copy-file": "~0.3",
     "drupal-composer/drupal-scaffold": "^2",
     "drupal/admin_toolbar": "^1.0",
     "drupal/adminimal_admin_toolbar": "^1.9",
@@ -24,7 +25,9 @@
     "drupal/fontawesome": "^2.12",
     "drupal/paragraphs": "^1.6",
     "drupal/pathauto": "^1.3",
-    "drupal/radix": "4.x-dev"
+    "drupal/radix": "4.x-dev",
+    "drupal/swagger_ui_formatter": "^2.1",
+    "swagger-api/swagger-ui": "^3.21"
   },
   "require-dev": {
     "drush/drush": "~9",
@@ -38,7 +41,11 @@
   },
   "scripts": {
     "post-install-cmd": [
-      "@composer drupal-scaffold"
+      "@composer drupal-scaffold",
+      "SlowProg\\CopyFile\\ScriptHandler::copy"
+    ],
+    "post-update-cmd": [
+      "SlowProg\\CopyFile\\ScriptHandler::copy"
     ],
     "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold"
   },
@@ -63,6 +70,9 @@
         "type:drupal-theme"
       ]
     },
-    "enable-patching": true
+    "enable-patching": true,
+    "copy-file": {
+      "vendor/swagger-api/swagger-ui/": "web/libraries/swagger_ui"
+    }
   }
 }

--- a/config/install/core.entity_view_display.apidoc.apidoc.default.yml
+++ b/config/install/core.entity_view_display.apidoc.apidoc.default.yml
@@ -8,7 +8,7 @@ dependencies:
     - field.field.apidoc.apidoc.field_image
   module:
     - apigee_edge_apidocs
-    - file
+    - swagger_ui_formatter
     - text
 id: apidoc.apidoc.default
 targetEntityType: apidoc
@@ -64,12 +64,24 @@ content:
       link_to_entity: false
     third_party_settings: {  }
   spec:
-    label: inline
-    type: file_default
-    weight: 6
+    label: hidden
+    type: swagger_ui
+    weight: 3
     region: content
     settings:
-      use_description_as_link_text: true
+      validator: default
+      validator_url: ''
+      doc_expansion: list
+      show_top_bar: false
+      sort_tags_by_name: false
+      supported_submit_methods:
+        get: '0'
+        put: '0'
+        post: '0'
+        delete: '0'
+        options: '0'
+        head: '0'
+        patch: '0'
     third_party_settings: {  }
 hidden:
   api_product: true


### PR DESCRIPTION
Adds the swagger formatter to the default view of the API Docs. This PR:

- Adds the swagger_ui library.
- Adds the swagger_ui_formatter module and config.

Important note:
The _swagger_ui_formatter_ module uses drupal libraries, not composer, to load Swagger UI, and as such, it expects the library in _web/libraries_, and not in _vendor_. To allow for an automated installation I've added a composer "copy dir" plugin (_slowprog/composer-copy-file_), and we would need to update _apigee/devportal-kickstart-project-composer_ "scripts" and "extra" sections to the following:


```
"scripts": {
    "post-install-cmd": [
      "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
      "SlowProg\\CopyFile\\ScriptHandler::copy"
    ],
    "post-update-cmd": [
      "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
      "SlowProg\\CopyFile\\ScriptHandler::copy"
    ],
    "quick-start": [
      "composer install",
      "php web/core/scripts/drupal quick-start apigee_devportal_kickstart"
    ]
  },
  "extra": {
    "installer-paths": {
      "web/core": ["type:drupal-core"],
      "web/libraries/{$name}": ["type:drupal-library"],
      "web/modules/contrib/{$name}": ["type:drupal-module"],
      "web/profiles/contrib/{$name}": ["type:drupal-profile"],
      "web/themes/contrib/{$name}": ["type:drupal-theme"]
    },
    "enable-patching": true,
    "copy-file": {
      "vendor/swagger-api/swagger-ui/": "web/libraries/swagger_ui"
    }
  }
```
When testing this PR, be sure to update your project's root composer with the above.
