### PR TITLE
[DRUP-536] Add container to page title block

### DIFF
--- a/themes/custom/apigee_kickstart/templates/block/block--page-title-block.html.twig
+++ b/themes/custom/apigee_kickstart/templates/block/block--page-title-block.html.twig
@@ -1,0 +1,13 @@
+{#
+/**
+ * @file
+ * Template for the page title block.
+ */
+#}
+{% embed '@radix/block/block.twig' with { html_tag: 'div' } %}
+  {% block content %}
+    <div class="container">
+      {{ content }}
+    </div>
+  {% endblock %}
+{% endembed %}


### PR DESCRIPTION
Quick PR to give the standard page title back some layout.