### PR TITLE
Point drupal/swagger_ui_formatter to 2.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "drupal/paragraphs": "^1.6",
     "drupal/pathauto": "^1.3",
     "drupal/radix": "4.x-dev",
-    "drupal/swagger_ui_formatter": "^2.1",
+    "drupal/swagger_ui_formatter": "2.x-dev",
     "swagger-api/swagger-ui": "^3.21"
   },
   "require-dev": {


### PR DESCRIPTION
We need to use the dev version of `drupal/swagger_ui_formatter`, pending the release of 8.x-2.2, to include the fixes for [hook_requirements return type should be an array](https://www.drupal.org/node/3027736).