### PR TITLE
[DRUP-536] Fix the title bar styles, improve formatted text on mobile.

### DIFF
--- a/themes/custom/apigee_kickstart/assets/css/apigee-kickstart.style.css
+++ b/themes/custom/apigee_kickstart/assets/css/apigee-kickstart.style.css
@@ -10162,6 +10162,11 @@ ul.social-links li a {
 .title-bar__title {
   margin: 0;
 }
+@media (max-width: 767.98px) {
+  .title-bar__title {
+    font-size: 1.5rem;
+  }
+}
 
 .title-bar__icon {
   align-items: center;
@@ -10191,7 +10196,7 @@ ul.social-links li a {
 }
 
 .title-bar__content {
-  border-color: #555 !important;
+  border-color: #a3a3a3 !important;
   font-size: 0.875rem;
   letter-spacing: 0.25px;
   line-height: 1.25;
@@ -10207,8 +10212,21 @@ ul.social-links li a {
   margin-top: 2rem;
   margin-bottom: 1rem;
 }
+@media (max-width: 767.98px) {
+  .text h2, .text h3, .text h4, .text h5, .text h5 {
+    margin-top: 1.5rem;
+  }
+}
 .text h2 {
   font-size: 2.215rem;
+}
+@media (max-width: 767.98px) {
+  .text h2 {
+    font-size: 1.5rem;
+  }
+}
+.text .text__field-text h2:first-child {
+  margin-top: 0;
 }
 .text h3 {
   font-size: 1.25rem;

--- a/themes/custom/apigee_kickstart/src/components/text/_text.scss
+++ b/themes/custom/apigee_kickstart/src/components/text/_text.scss
@@ -6,10 +6,22 @@
   h2, h3, h4, h5, h5 {
     margin-top: 2rem;
     margin-bottom: 1rem;
+
+    @include media-breakpoint-down(sm) {
+      margin-top: 1.5rem;
+    }
   }
 
   h2 {
     font-size: 2.215rem;
+
+    @include media-breakpoint-down(sm) {
+      font-size: 1.5rem;
+    }
+  }
+
+  .text__field-text h2:first-child {
+    margin-top: 0;
   }
 
   h3 {

--- a/themes/custom/apigee_kickstart/src/components/title-bar/_title-bar.scss
+++ b/themes/custom/apigee_kickstart/src/components/title-bar/_title-bar.scss
@@ -6,6 +6,10 @@
 
 .title-bar__title {
   margin: 0;
+
+  @include media-breakpoint-down(sm) {
+    font-size: 1.5rem;
+  }
 }
 
 // @todo... Workaround .field from apigee_edge 😢
@@ -36,7 +40,7 @@
 }
 
 .title-bar__content {
-  border-color: $body-color !important;
+  border-color: $gray-500 !important;
   font-size: 0.875rem;
   letter-spacing: 0.25px;
   line-height: 1.25;

--- a/themes/custom/apigee_kickstart/templates/field/field--paragraph--field-icon--title-bar.html.twig
+++ b/themes/custom/apigee_kickstart/templates/field/field--paragraph--field-icon--title-bar.html.twig
@@ -1,0 +1,9 @@
+{#
+/**
+ * @file
+ * Template for field_cards on a 'Title bar' Paragraph.
+ */
+#}
+{%- for item in items -%}
+  {{- item.content -}}
+{%- endfor -%}

--- a/themes/custom/apigee_kickstart/templates/field/field--paragraph--field-title--title-bar.html.twig
+++ b/themes/custom/apigee_kickstart/templates/field/field--paragraph--field-title--title-bar.html.twig
@@ -5,5 +5,5 @@
  */
 #}
 {%- for item in items -%}
-  <h1 class="title-bar__title">{{- item.content -}}</h1>
+  <h1 class="title-bar__title pr-4">{{- item.content -}}</h1>
 {%- endfor -%}

--- a/themes/custom/apigee_kickstart/templates/paragraph/paragraph--title-bar.html.twig
+++ b/themes/custom/apigee_kickstart/templates/paragraph/paragraph--title-bar.html.twig
@@ -8,15 +8,13 @@
   {% block content %}
     <div class="container">
       <div class="d-flex align-items-center">
-        <div class="title-bar__title flex-grow-1 flex-grow-md-0 pr-4">
-          {{ content.field_title }}
-        </div>
+        {{ content.field_title }}
         {% if content.field_text|render %}
-          <div class="title-bar__content border-left d-none d-lg-block flex-grow-1 pl-4">
+          <div class="title-bar__content border-left d-none d-lg-block pl-4 flex-grow-1">
             {{ content|without('field_title', 'field_icon') }}
           </div>
         {% endif %}
-        <div class="title-bar__icon pl-4">
+        <div class="title-bar__icon">
           {{ content.field_icon }}
         </div>
       </div>


### PR DESCRIPTION
## Large
![title-bar large](https://user-images.githubusercontent.com/60979/55342823-a81fab80-5477-11e9-945a-3a53ecd43211.png)

## Small
![title-bar small](https://user-images.githubusercontent.com/60979/55342824-a81fab80-5477-11e9-9968-ef5f37ca34dc.png)

Edit: ^ I accidentally had "started" text selected w/my mouse, it's not actually that color. 😛 