### PR TITLE
DRUP-673 Expose First and Last name base fields for User profile

### DIFF
--- a/modules/custom/apigee_kickstart_enhancement/apigee_kickstart_enhancement.module
+++ b/modules/custom/apigee_kickstart_enhancement/apigee_kickstart_enhancement.module
@@ -25,6 +25,8 @@
 
 use Drupal\apigee_kickstart_enhancement\Entity\ApiDocViewBuilder;
 use Drupal\apigee_kickstart_enhancement\Entity\AppViewBuilder;
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Menu\LocalActionDefault;
 
 /*
@@ -88,5 +90,32 @@ function apigee_kickstart_enhancement_entity_type_alter(array &$entity_types) {
   // entities in one ViewBuilder.
   if (isset($entity_types['apidoc'])) {
     $entity_types['apidoc']->setViewBuilderClass(ApiDocViewBuilder::class);
+  }
+}
+
+/**
+ * Implements hook_entity_extra_field_info().
+ */
+function apigee_kickstart_enhancement_entity_extra_field_info() {
+  // Make the user display name configurable.
+  // In Apigee Edge, this is the entity label.
+  $fields['user']['user']['display']['display_name'] = [
+    'label' => t('Name'),
+    'description' => t('The name from Apigee Edge.'),
+    'weight' => -10,
+    'visible' => TRUE,
+  ];
+
+  return $fields;
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_view().
+ */
+function apigee_kickstart_enhancement_user_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
+  if ($display->getComponent('display_name')) {
+    $build['display_name'] = [
+      '#markup' => $entity->label(),
+    ];
   }
 }


### PR DESCRIPTION
This makes the user display name configurable via the UI.

Use `{{ content.display_name }}` to render in a Twig template.

![Manage_display___Apigee](https://user-images.githubusercontent.com/124599/55350525-615ca080-54cd-11e9-884a-d70ffeef9c62.jpg)