### PR TITLE
DRUP-530 Fix swagger_ui_formatter error on installation

### DIFF
--- a/apigee_devportal_kickstart.info.yml
+++ b/apigee_devportal_kickstart.info.yml
@@ -65,6 +65,7 @@ install:
 - forum
 - paragraphs
 - pathauto
+- swagger_ui_formatter
 
 # List any themes that should be installed as part of the profile installation.
 # Note that this will not set any theme as the default theme.

--- a/apigee_devportal_kickstart.install
+++ b/apigee_devportal_kickstart.install
@@ -38,11 +38,10 @@ function apigee_devportal_kickstart_install() {
   $src_path = drupal_get_path('profile', 'apigee_devportal_kickstart') . '/resources/files';
 
   // Get public files directory.
-  $dest_path = \Drupal::service('file_system')->realpath(file_default_scheme() . '://');
+  $dest_path = file_default_scheme() . '://';
 
   // Files to copy.
   // Not all files are copied. So we list them here individually.
-  // TODO: Figure out if we can improve this.
   $filesets = [
     '' => [
       'aditya-vyas-1392552-unsplash.jpg',
@@ -54,8 +53,8 @@ function apigee_devportal_kickstart_install() {
       'spacex-81773-unsplash.jpg',
       'terence-burke-1417892-unsplash.jpg',
     ],
-    'apidoc_specs' => [
-      'petstore.yml',
+    'apidoc_specs/' => [
+      'petstore.yaml',
     ],
   ];
 
@@ -65,7 +64,11 @@ function apigee_devportal_kickstart_install() {
       if (file_exists($src_path . '/' . $file)) {
         // If the file exists in public://, it should be skipped, as these are
         // tied to media entities which hard-code the path/file.
-        file_unmanaged_copy($src_path . '/' . $file, $dest_path . '/' . $destination);
+        $directory = $dest_path . $destination;
+        if (!empty($destination)) {
+          file_prepare_directory($directory, FILE_CREATE_DIRECTORY);
+        }
+        file_unmanaged_copy($src_path . '/' . $file, $directory. $file);
       }
     }
   }

--- a/config/install/core.entity_view_display.apidoc.apidoc.default.yml
+++ b/config/install/core.entity_view_display.apidoc.apidoc.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.apidoc.apidoc.field_image
   module:
     - apigee_edge_apidocs
+    - swagger_ui_formatter
 id: apidoc.apidoc.default
 targetEntityType: apidoc
 bundle: apidoc
@@ -18,6 +19,26 @@ content:
     label: hidden
     settings:
       link: true
+    third_party_settings: {  }
+  spec:
+    label: hidden
+    type: swagger_ui_file
+    weight: 3
+    region: content
+    settings:
+      validator: default
+      validator_url: ''
+      doc_expansion: list
+      show_top_bar: false
+      sort_tags_by_name: false
+      supported_submit_methods:
+        get: '0'
+        put: '0'
+        post: '0'
+        delete: '0'
+        options: '0'
+        head: '0'
+        patch: '0'
     third_party_settings: {  }
 hidden:
   description: true


### PR DESCRIPTION
This fixes the swagger field plugin configuration, and it also fixes the petstore.yaml file that was missing upon installation.