### PR TITLE
Make Card Component Hover Shadow Optional

### DIFF
--- a/themes/custom/apigee_kickstart/assets/css/apigee-kickstart.style.css
+++ b/themes/custom/apigee_kickstart/assets/css/apigee-kickstart.style.css
@@ -9849,12 +9849,12 @@ small {
 .card-footer, .card-footer:last-child {
   border-radius: 0 0 4px 4px;
 }
-.card:focus, .card:hover {
-  box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.3);
-}
 .card:focus .card-footer, .card:hover .card-footer {
   background-color: #2196f3;
   color: #fff;
+}
+.card.has-hover-shadow:focus, .card.has-hover-shadow:hover {
+  box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.3);
 }
 
 .api-card {
@@ -10596,10 +10596,6 @@ details .form-select {
   background-color: #fff;
   overflow: hidden;
   font-size: 0.875rem;
-}
-.views-exposed-form .card:focus,
-.views-exposed-form .card:hover {
-  box-shadow: none;
 }
 .views-exposed-form fieldset,
 .views-exposed-form details {

--- a/themes/custom/apigee_kickstart/src/components/card/_card.scss
+++ b/themes/custom/apigee_kickstart/src/components/card/_card.scss
@@ -52,11 +52,14 @@
 
   &:focus,
   &:hover {
-    box-shadow: 0 2px 8px 0 rgba($black, 0.3);
-
     .card-footer {
       background-color: $primary;
       color: $white;
     }
+  }
+
+  &.has-hover-shadow:focus,
+  &.has-hover-shadow:hover {
+    box-shadow: 0 2px 8px 0 rgba($black, 0.3);
   }
 }

--- a/themes/custom/apigee_kickstart/src/components/card/card.twig
+++ b/themes/custom/apigee_kickstart/src/components/card/card.twig
@@ -4,8 +4,11 @@
  * Template for a Card component.
  */
 #}
+
+{% set hover_shadow = hover_shadow|default(false) %}
 {% set classes = [
-  'card'
+  'card',
+  hover_shadow ? 'has-hover-shadow' : ''
 ]|merge(classes|default([])) %}
 
 <div class="{{ classes|join(' ')|trim }}">

--- a/themes/custom/apigee_kickstart/src/sass/form/_view.exposed-form.scss
+++ b/themes/custom/apigee_kickstart/src/sass/form/_view.exposed-form.scss
@@ -6,11 +6,6 @@
   overflow: hidden;
   font-size: .875rem;
 
-  .card:focus,
-  .card:hover {
-    box-shadow: none;
-  }
-
   fieldset,
   details {
     margin: 0 !important;

--- a/themes/custom/apigee_kickstart/templates/apigee/apidoc--card.html.twig
+++ b/themes/custom/apigee_kickstart/templates/apigee/apidoc--card.html.twig
@@ -24,6 +24,7 @@
     title: entity.label,
     image: content.field_image,
     body: content|without('name', 'field_image', 'field_link'),
-    footer: content.field_link['#title']
+    footer: content.field_link['#title'],
+    hover_shadow: true
   } %}
 </article>

--- a/themes/custom/apigee_kickstart/templates/paragraph/paragraph--card.html.twig
+++ b/themes/custom/apigee_kickstart/templates/paragraph/paragraph--card.html.twig
@@ -13,7 +13,8 @@
     title: content.field_title,
     body: content|without('field_image', 'field_link', 'field_title'),
     footer: content.field_link.0['#title'],
-    url: content.field_link.0['#url']
+    url: content.field_link.0['#url'],
+    hover_shadow: true
   } %}
 
 {% endblock %}


### PR DESCRIPTION
This facilitates:

- Showing the shadow on API Docs and Card Paragraphs.
- Not showing it on comments, views exposed filers, etc.