### PR TITLE
DRUP-688 Remove core patch for drupal.org issue #2951487

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,9 +64,6 @@
       "drupal/core": "-p2"
     },
     "patches": {
-      "drupal/core": {
-        "`EntityViewBuilder::getBuildDefaults()` doesn't check for `RevisionableInterface`.": "https://www.drupal.org/files/issues/2019-01-10/2951487_15_no-tests.patch"
-      },
       "drupal/better_exposed_filters": {
         "Fix issue with #summary_details introduced in Drupal 8.6.x": "https://www.drupal.org/files/issues/2018-10-05/bef-summary-attributes-3001967-4.patch"
       }


### PR DESCRIPTION
If/when apigee/apigee-edge-drupal#171 gets merged, this PR will remove the core patch that will not be needed anymore.
