### PR TITLE
Add the active indicator to the link, as well as the <li>.

### DIFF
--- a/themes/custom/apigee_kickstart/assets/css/apigee-kickstart.style.css
+++ b/themes/custom/apigee_kickstart/assets/css/apigee-kickstart.style.css
@@ -10619,7 +10619,10 @@ fieldset.closed legend button {
 .navbar-nav .nav-item {
   position: relative;
 }
-.navbar-nav .nav-item.active:after {
+.navbar-nav .nav-item .active .nav-link {
+  color: var(--ak-header-color);
+}
+.navbar-nav .nav-item .nav-link.is-active::after, .navbar-nav .nav-item.active::after {
   content: "";
   position: absolute;
   left: 0.5rem;
@@ -10630,12 +10633,9 @@ fieldset.closed legend button {
   display: none;
 }
 @media (min-width: 992px) {
-  .navbar-nav .nav-item.active:after {
+  .navbar-nav .nav-item .nav-link.is-active::after, .navbar-nav .nav-item.active::after {
     display: block;
   }
-}
-.navbar-nav .nav-item.active .nav-link {
-  color: var(--ak-header-color);
 }
 
 .navbar-brand {

--- a/themes/custom/apigee_kickstart/src/components/navbar/_navbar.scss
+++ b/themes/custom/apigee_kickstart/src/components/navbar/_navbar.scss
@@ -47,25 +47,23 @@
 .navbar-nav .nav-item {
   position: relative;
 
-  &.active {
+  .active .nav-link {
+    color: var(--ak-header-color);
+  }
 
-    &:after {
-      content: '';
-      position: absolute;
-      left: 0.5rem;
-      right: 0.5rem;
-      bottom: 2px;
-      height: 2px;
-      background-color: var(--ak-accent-color);
-      display: none;
+  .nav-link.is-active::after,
+  &.active::after {
+    content: '';
+    position: absolute;
+    left: 0.5rem;
+    right: 0.5rem;
+    bottom: 2px;
+    height: 2px;
+    background-color: var(--ak-accent-color);
+    display: none;
 
-      @include media-breakpoint-up(lg) {
-        display: block;
-      }
-    }
-
-    .nav-link {
-      color: var(--ak-header-color); // $white
+    @include media-breakpoint-up(lg) {
+      display: block;
     }
   }
 }


### PR DESCRIPTION
This fixes the "APIs" link when active.

<img width="657" alt="Screen Shot 2019-04-08 at 2 42 07 PM" src="https://user-images.githubusercontent.com/60979/55748436-ae300200-5a0c-11e9-9673-79ae3b3788b8.png">
