### PR TITLE
[DRUP-731] Fix QuickEdit JavaScript error

### DIFF
--- a/themes/custom/apigee_kickstart/src/components/card/card.twig
+++ b/themes/custom/apigee_kickstart/src/components/card/card.twig
@@ -12,7 +12,7 @@
 ]|merge(classes|default([])) %}
 
 {% if print_attributes and attributes %}
-  {# This is a workaround for QuickEdit, to allows the extending template to
+  {# This is a workaround for QuickEdit that allows the extending template to
   print the attributes in this component template, as opposed to the paragraph
   wrapper. When displaying a card in a cark deck, the card needs to be a direct
   descendant, and cannot have an "extra" element in between. Just removing the

--- a/themes/custom/apigee_kickstart/src/components/card/card.twig
+++ b/themes/custom/apigee_kickstart/src/components/card/card.twig
@@ -37,7 +37,7 @@
     {% if title or body %}
       <div class="card-body">
         {% if title %}
-          <h4>{{ title }}</h4>
+          <h4 class="card-title">{{ title }}</h4>
         {% endif %}
         {% block body %}
           {{ body }}

--- a/themes/custom/apigee_kickstart/src/components/card/card.twig
+++ b/themes/custom/apigee_kickstart/src/components/card/card.twig
@@ -11,7 +11,19 @@
   hover_shadow ? 'has-hover-shadow' : ''
 ]|merge(classes|default([])) %}
 
-<div class="{{ classes|join(' ')|trim }}">
+{% if print_attributes and attributes %}
+  {# This is a workaround for QuickEdit, to allows the extending template to
+  print the attributes in this component template, as opposed to the paragraph
+  wrapper. When displaying a card in a cark deck, the card needs to be a direct
+  descendant, and cannot have an "extra" element in between. Just removing the
+  Paragraph wrapper is an option, but doing so also omits attributes needed by
+  QuickEdit, and that cause a JavaScript error. This code allows both attributes
+  to be printed, and the card deck component to work as designed. #}
+  <div{{ attributes.addClass(classes) }}
+{% else %}
+  <div class="{{ classes|join(' ')|trim }}">
+{% endif %}
+
   {% if url %}
     <a href="{{ url }}">
   {% endif %}

--- a/themes/custom/apigee_kickstart/templates/paragraph/paragraph--card.html.twig
+++ b/themes/custom/apigee_kickstart/templates/paragraph/paragraph--card.html.twig
@@ -8,6 +8,7 @@
 {% block paragraph %}
 
   {% include '@apigee-kickstart/card/card.twig' with {
+    print_attributes: true,
     classes: classes,
     image: content.field_image,
     title: content.field_title,


### PR DESCRIPTION
Resolves the following error:

## Before 👎 

<img width="924" alt="quickedit-before" src="https://user-images.githubusercontent.com/60979/55980734-15df8a80-5c63-11e9-9112-dd972f1616fd.png">

## After 👍 

<img width="923" alt="quickedit-after" src="https://user-images.githubusercontent.com/60979/55980735-15df8a80-5c63-11e9-8776-43241f4ca107.png">
