### PR TITLE
[DRUP-529] Add a task to allow Edge creds to be set during Drupal installation

### DIFF
--- a/apigee_devportal_kickstart.install
+++ b/apigee_devportal_kickstart.install
@@ -23,6 +23,7 @@
  * Install, update and uninstall functions for Apigee Kickstart profile.
  */
 
+use Drupal\apigee_devportal_kickstart\Installer\Form\ApigeeEdgeConfigurationForm;
 use Drupal\Core\Messenger\MessengerInterface;
 
 /**
@@ -71,10 +72,28 @@ function apigee_devportal_kickstart_install() {
         if (!empty($destination)) {
           file_prepare_directory($directory, FILE_CREATE_DIRECTORY);
         }
-        file_unmanaged_copy($src_path . '/' . $file, $directory. $file);
+        file_unmanaged_copy($src_path . '/' . $file, $directory . $file);
       }
     }
   }
+}
+
+/**
+ * Implements hook_install_tasks_alter().
+ */
+function apigee_devportal_kickstart_install_tasks_alter(&$tasks, $install_state) {
+  // Add a task for configuring Apigee Edge Authentication.
+  $tasks_copy = $tasks;
+  $apigee_edge_configure_form = [
+    'apigee_edge_configure_form' => [
+      'display_name' => t('Configure Apigee Edge'),
+      'type' => 'form',
+      'function' => ApigeeEdgeConfigurationForm::class,
+    ],
+  ];
+
+  // The task should run before install_configure_form which creates the user.
+  $tasks = array_slice($tasks_copy, 0, array_search('install_configure_form', array_keys($tasks))) + $apigee_edge_configure_form + $tasks_copy;
 }
 
 /**

--- a/config/install/apigee_edge.auth.yml
+++ b/config/install/apigee_edge.auth.yml
@@ -1,0 +1,2 @@
+active_key: apigee_edge_connection_default
+active_key_oauth_token: ''

--- a/config/install/key.key.apigee_edge_connection_default.yml
+++ b/config/install/key.key.apigee_edge_connection_default.yml
@@ -1,0 +1,14 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - apigee_edge
+id: apigee_edge_connection_default
+label: 'Apigee Edge connection'
+description: 'Contains the credentials for connecting to Apigee Edge.'
+key_type: apigee_auth
+key_type_settings: {  }
+key_provider: config
+key_provider_settings: {  }
+key_input: apigee_auth_input
+key_input_settings: {  }

--- a/src/Installer/Form/ApigeeEdgeConfigurationForm.php
+++ b/src/Installer/Form/ApigeeEdgeConfigurationForm.php
@@ -39,6 +39,19 @@ class ApigeeEdgeConfigurationForm extends AuthenticationForm {
     // Add a form title for the installer.
     $form['#title'] = $this->t('Configure Apigee Edge');
 
+    // Show help text.
+    $form['help'] = [
+      '#theme' => 'status_messages',
+      '#message_list' => [
+        MessengerInterface::TYPE_WARNING => [
+          $this->t('Note: Your connection settings are going to be saved in Drupal\'s configuration system. If you wish to do this later or <a href=":url" target="_blank">use a different key provider</a>, you may skip this step.', [
+            ':url' => 'https://www.drupal.org/docs/8/modules/apigee-edge/configure-the-connection-to-apigee-edge',
+          ]),
+        ],
+      ],
+      '#weight' => -100,
+    ];
+
     // Hide the test_connection fields.
     $form['test_connection']['#access'] = FALSE;
 

--- a/src/Installer/Form/ApigeeEdgeConfigurationForm.php
+++ b/src/Installer/Form/ApigeeEdgeConfigurationForm.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * @file
+ * Copyright 2019 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_devportal_kickstart\Installer\Form;
+
+use Drupal\apigee_edge\Form\AuthenticationForm;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Configuration form for Apigee Edge.
+ */
+class ApigeeEdgeConfigurationForm extends AuthenticationForm {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildForm($form, $form_state);
+
+    // Add a form title for the installer.
+    $form['#title'] = $this->t('Configure Apigee Edge');
+
+    // Hide the test_connection fields.
+    $form['test_connection']['#access'] = FALSE;
+
+    // Add a skip this step button.
+    $form['actions']['skip'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Skip this step'),
+      '#submit' => [[$this, 'skipStepSubmit']],
+      '#validate' => [],
+      '#limit_validation_errors' => [],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    // Do validation if not skip button.
+    if ((string) $form_state->getValue('op') !== (string) $form['actions']['skip']['#value']) {
+      parent::validateForm($form, $form_state);
+    }
+  }
+
+  /**
+   * Provides a submit handler for the skip step button.
+   *
+   * @param array $form
+   *   The form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public function skipStepSubmit(array $form, FormStateInterface $form_state) {
+    global $install_state;
+    $install_state['completed_task'] = install_verify_completed_task();
+  }
+
+}


### PR DESCRIPTION
This PR adds a "Configure Apigee Edge" task to the installer. This uses the authentication form shipped with Edge with a few bug fixes. There's a `Skip this step` added.

![apigee_ks_edge](https://user-images.githubusercontent.com/124599/56061223-dfe0fa00-5d79-11e9-96c1-fb4a58ae9895.jpg)
