### PR TITLE
DRUP-727 Added support for team apps listing

### DIFF
--- a/modules/custom/apigee_kickstart_enhancement/src/Entity/ListBuilder/DeveloperAppListBuilder.php
+++ b/modules/custom/apigee_kickstart_enhancement/src/Entity/ListBuilder/DeveloperAppListBuilder.php
@@ -25,7 +25,7 @@ use Drupal\apigee_edge\Entity\ListBuilder\DeveloperAppListBuilderForDeveloper;
 /**
  * Renders the Apps list as a list of entity views instead of a table.
  */
-class AppListBuilder extends DeveloperAppListBuilderForDeveloper {
+class DeveloperAppListBuilder extends DeveloperAppListBuilderForDeveloper {
 
   /**
    * {@inheritdoc}

--- a/modules/custom/apigee_kickstart_enhancement/src/Entity/ListBuilder/TeamAppListBuilder.php
+++ b/modules/custom/apigee_kickstart_enhancement/src/Entity/ListBuilder/TeamAppListBuilder.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_kickstart_enhancement\Entity\ListBuilder;
+
+use Drupal\apigee_edge_teams\Entity\ListBuilder\TeamAppListByTeam;
+
+/**
+ * Renders the Apps list as a list of entity views instead of a table.
+ */
+class TeamAppListBuilder extends TeamAppListByTeam {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render() {
+    $build = [];
+    $view_builder = $this->entityTypeManager->getViewBuilder($this->entityTypeId);
+
+    // Render a list of apps.
+    // We cannot do ViewBuilder::viewMultiple here because \Drupal\apigee_edge\Entity\AppViewBuilder::buildMultiple
+    // assumes $build_list is an array of render arrays whereas $build_list may
+    // contain non-renderaable elements. Example: #sorted or #pre_render.
+    foreach ($this->load() as $entity) {
+      $build[] = $view_builder->view($entity, 'collapsible_card');
+    }
+
+    return $build;
+  }
+
+}

--- a/modules/custom/apigee_kickstart_enhancement/src/Routing/RouteSubscriber.php
+++ b/modules/custom/apigee_kickstart_enhancement/src/Routing/RouteSubscriber.php
@@ -22,6 +22,7 @@ namespace Drupal\apigee_kickstart_enhancement\Routing;
 
 use Drupal\apigee_kickstart_enhancement\ApigeeKickStartEnhancerInterface;
 use Drupal\apigee_kickstart_enhancement\Entity\ListBuilder\AppListBuilder;
+use Drupal\apigee_kickstart_enhancement\Entity\ListBuilder\TeamAppListBuilder;
 use Drupal\Core\Routing\RouteSubscriberBase;
 use Symfony\Component\Routing\RouteCollection;
 
@@ -55,7 +56,12 @@ class RouteSubscriber extends RouteSubscriberBase {
     /** @var \Drupal\Core\Entity\EntityTypeInterface $app_entity_type */
     foreach (\Drupal::service('apigee_kickstart.enhancer')->getAppEntityTypes() as $entity_type_id => $app_entity_type) {
       if ($route = $collection->get("entity.$entity_type_id.collection_by_" . str_replace('_app', '', $entity_type_id))) {
-        $route->setDefault('_controller', AppListBuilder::class . '::render');
+        if ($entity_type_id == 'team_app') {
+          $route->setDefault('_controller', TeamAppListBuilder::class . '::render');
+        }
+        else {
+          $route->setDefault('_controller', AppListBuilder::class . '::render');
+        }
       }
     }
   }

--- a/modules/custom/apigee_kickstart_enhancement/src/Routing/RouteSubscriber.php
+++ b/modules/custom/apigee_kickstart_enhancement/src/Routing/RouteSubscriber.php
@@ -21,7 +21,7 @@
 namespace Drupal\apigee_kickstart_enhancement\Routing;
 
 use Drupal\apigee_kickstart_enhancement\ApigeeKickStartEnhancerInterface;
-use Drupal\apigee_kickstart_enhancement\Entity\ListBuilder\AppListBuilder;
+use Drupal\apigee_kickstart_enhancement\Entity\ListBuilder\DeveloperAppListBuilder;
 use Drupal\apigee_kickstart_enhancement\Entity\ListBuilder\TeamAppListBuilder;
 use Drupal\Core\Routing\RouteSubscriberBase;
 use Symfony\Component\Routing\RouteCollection;
@@ -60,7 +60,7 @@ class RouteSubscriber extends RouteSubscriberBase {
           $route->setDefault('_controller', TeamAppListBuilder::class . '::render');
         }
         else {
-          $route->setDefault('_controller', AppListBuilder::class . '::render');
+          $route->setDefault('_controller', DeveloperAppListBuilder::class . '::render');
         }
       }
     }

--- a/themes/custom/apigee_kickstart/includes/apigee.inc
+++ b/themes/custom/apigee_kickstart/includes/apigee.inc
@@ -31,7 +31,25 @@ function apigee_kickstart_preprocess_app(array &$variables) {
 
   // Add local tasks on the app canonical route as additional tabs.
   $variables['additional_tabs'] = [];
-  $canonical_route_name = "entity.{$app->getEntityTypeId()}.canonical_by_" . str_replace('_app', '', $app->getEntityTypeId());
+
+  switch ($app->getEntityTypeId()) {
+    case 'team_app':
+      $canonical_route_name = 'entity.team_app.canonical';
+      $route_parameters = [
+        'team' => $app->getAppOwner(),
+        'app' => $app->getName(),
+      ];
+      break;
+
+    default:
+      $canonical_route_name = "entity.{$app->getEntityTypeId()}.canonical_by_" . str_replace('_app', '', $app->getEntityTypeId());
+      $route_parameters = [
+        'user' => $app->getOwnerId(),
+        'app' => $app->getName(),
+      ];
+      break;
+  }
+
   if ($tasks = Drupal::service('plugin.manager.menu.local_task')->getLocalTasks($canonical_route_name)) {
     foreach ($tasks['tabs'] as $tab) {
       $link = $tab['#link'];
@@ -39,10 +57,7 @@ function apigee_kickstart_preprocess_app(array &$variables) {
       /** @var \Drupal\Core\Url $url */
       $url = $link['url'];
       if ($url->getRouteName() !== $canonical_route_name) {
-        $url->setRouteParameters([
-          'user' => $app->getOwnerId(),
-          'app' => $app->getName(),
-        ]);
+        $url->setRouteParameters($route_parameters);
 
         $variables['additional_tabs'][] = [
           'title' => $link['title'],


### PR DESCRIPTION
This will fix an error that is getting thrown on paths like /teams/test-company2/apps, and adds the card format to team apps, just like developer apps (for an example look at /teams/my_team/apps).