### PR TITLE
[DRUP-719] Fix layout when content field is empty 

### DIFF
--- a/themes/custom/apigee_kickstart/templates/page/page--node--landing.html.twig
+++ b/themes/custom/apigee_kickstart/templates/page/page--node--landing.html.twig
@@ -1,0 +1,10 @@
+{#
+/**
+ * @file
+ * Template for an Landing page layout.
+ */
+#}
+{% extends 'page.html.twig' %}
+{% block content %}
+  {{ page.content }}
+{% endblock %}

--- a/themes/custom/apigee_kickstart/templates/page/page.html.twig
+++ b/themes/custom/apigee_kickstart/templates/page/page.html.twig
@@ -81,11 +81,11 @@
     {% block content %}
       {% if page.content %}
         <div class="page__content">
-          {% if not node.field_content.value %}
+          {% if not node.field_content %}
             <div class="container py-5">
           {% endif %}
             {{ page.content }}
-          {% if not node.field_content.value %}
+          {% if not node.field_content %}
             </div>
           {% endif %}
         </div>

--- a/themes/custom/apigee_kickstart/templates/page/page.html.twig
+++ b/themes/custom/apigee_kickstart/templates/page/page.html.twig
@@ -81,13 +81,9 @@
     {% block content %}
       {% if page.content %}
         <div class="page__content">
-          {% if not node.field_content %}
-            <div class="container py-5">
-          {% endif %}
+          <div class="container py-5">
             {{ page.content }}
-          {% if not node.field_content %}
-            </div>
-          {% endif %}
+          </div>
         </div>
       {% endif %}
     {% endblock %}


### PR DESCRIPTION
Checking for the field is enough, as opposed to it needing to have a value. This resolves an issue where, creating a hero, for example, and leaving the content field blank, causes the wrong layout to be used:

<img width="1436" alt="hero-no-content" src="https://user-images.githubusercontent.com/60979/56302201-49109680-6107-11e9-9755-fbedac0e3fbf.png">
