### PR TITLE
[DRUP-677] Don’t override the FAQ title field template

### DIFF
--- a/themes/custom/apigee_kickstart/templates/field/field--node--title--faq.html.twig
+++ b/themes/custom/apigee_kickstart/templates/field/field--node--title--faq.html.twig
@@ -1,9 +1,0 @@
-{#
-/**
- * @file
- * Template for title on a 'FAQ' Node.
- */
-#}
-{%- for item in items -%}
-  <h2{{ attributes.addClass('details__title') }}>{{- item.content -}}</h2>
-{%- endfor -%}

--- a/themes/custom/apigee_kickstart/templates/node/node--faq--teaser.html.twig
+++ b/themes/custom/apigee_kickstart/templates/node/node--faq--teaser.html.twig
@@ -6,8 +6,13 @@
 #}
 {% extends '@apigee-kickstart/node/node.twig' %}
 {% block content %}
+
+  {%- set summary -%}
+    <h2 class="details__title">{{ label }}</h2>
+  {%- endset -%}
+
   {% include '@apigee-kickstart/details/details.twig' with {
-    summary: label,
+    summary: summary,
     content: content
   } %}
 {% endblock %}


### PR DESCRIPTION
Apparently it is used in the page_title block, which breaks our breadcrumbs on FAQ node detail.  This PR moves that markup to the node template to resolve the issue.

## Before

![breadcrumb faq broken](https://user-images.githubusercontent.com/60979/56302792-7c075a00-6108-11e9-8674-9100fe77fb67.png)

## After

![breadcrumb faq fixed](https://user-images.githubusercontent.com/60979/56302793-7c9ff080-6108-11e9-853b-7bc1c112c03b.png)
