### PR TITLE
[DRUP-740] Fix issues found while recording screencasts

### DIFF
--- a/config/install/core.entity_form_display.node.page.default.yml
+++ b/config/install/core.entity_form_display.node.page.default.yml
@@ -31,7 +31,7 @@ content:
     third_party_settings: {  }
   field_header:
     type: paragraphs
-    weight: 0
+    weight: 1
     region: content
     settings:
       title: Paragraph
@@ -77,7 +77,7 @@ content:
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 1
+    weight: 0
     region: content
     settings:
       size: 60

--- a/config/install/core.entity_form_display.paragraph.callout_group.default.yml
+++ b/config/install/core.entity_form_display.paragraph.callout_group.default.yml
@@ -21,7 +21,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_buttons:
-    weight: 2
+    weight: 3
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -41,7 +41,7 @@ content:
     region: content
   field_callouts:
     type: paragraphs
-    weight: 3
+    weight: 2
     settings:
       title: Paragraph
       title_plural: Paragraphs

--- a/config/install/core.entity_form_display.paragraph.card_group.default.yml
+++ b/config/install/core.entity_form_display.paragraph.card_group.default.yml
@@ -21,7 +21,7 @@ content:
     type: options_select
     region: content
   field_buttons:
-    weight: 2
+    weight: 3
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -41,7 +41,7 @@ content:
     region: content
   field_cards:
     type: paragraphs
-    weight: 3
+    weight: 2
     settings:
       title: Paragraph
       title_plural: Paragraphs

--- a/config/install/core.entity_form_display.paragraph.text_image.default.yml
+++ b/config/install/core.entity_form_display.paragraph.text_image.default.yml
@@ -24,26 +24,27 @@ content:
     type: options_select
     region: content
   field_buttons:
-    weight: 4
+    weight: 3
     settings:
       title: Paragraph
       title_plural: Paragraphs
       edit_mode: open
-      add_mode: dropdown
-      form_display_mode: default
-      default_paragraph_type: ''
       closed_mode: summary
       autocollapse: none
       closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: _none
       features:
         duplicate: duplicate
         collapse_edit_all: collapse_edit_all
+        add_above: '0'
     third_party_settings: {  }
     type: paragraphs
     region: content
   field_image:
     type: media_library_widget
-    weight: 3
+    weight: 4
     settings: {  }
     third_party_settings: {  }
     region: content

--- a/themes/custom/apigee_kickstart/assets/css/apigee-kickstart.style.css
+++ b/themes/custom/apigee_kickstart/assets/css/apigee-kickstart.style.css
@@ -10076,6 +10076,10 @@ body,
 .alert {
   font-size: 0.875rem;
   font-weight: 500;
+  margin-bottom: 0;
+}
+.container-fluid .alert, .container .alert {
+  margin-bottom: 1rem;
 }
 
 .blockquote {

--- a/themes/custom/apigee_kickstart/assets/css/apigee-kickstart.style.css
+++ b/themes/custom/apigee_kickstart/assets/css/apigee-kickstart.style.css
@@ -577,7 +577,8 @@ mark,
   height: auto;
 }
 
-.img-thumbnail {
+.img-thumbnail, .text img, [class$=__body] img,
+.cke_widget_image img {
   padding: 0.25rem;
   background-color: #fff;
   border: 1px solid #ddd;
@@ -10993,7 +10994,6 @@ ul.social-links li a {
 .text li {
   margin: 0.5rem 0;
 }
-
 .field,
 .wrapper--primary,
 .wrapper--secondary {

--- a/themes/custom/apigee_kickstart/src/components/alert/_alert.scss
+++ b/themes/custom/apigee_kickstart/src/components/alert/_alert.scss
@@ -1,6 +1,13 @@
 // Alert
 // -----------------------------------------------------------------------------
+
 .alert {
   font-size: .875rem;
   font-weight: 500;
+  margin-bottom: 0;
+
+  .container-fluid &,
+  .container & {
+    margin-bottom: $alert-margin-bottom;
+  }
 }

--- a/themes/custom/apigee_kickstart/src/components/node/_node.scss
+++ b/themes/custom/apigee_kickstart/src/components/node/_node.scss
@@ -1,5 +1,7 @@
 // Custom style for the Node component.
 // -----------------------------------------------------------------------------
-.node {
 
+[class$="__body"] img,
+.cke_widget_image img {
+  @extend .img-thumbnail;
 }

--- a/themes/custom/apigee_kickstart/src/components/text/_text.scss
+++ b/themes/custom/apigee_kickstart/src/components/text/_text.scss
@@ -35,4 +35,8 @@
   li {
     margin: 0.5rem 0;
   }
+
+  img {
+    @extend .img-thumbnail;
+  }
 }

--- a/themes/custom/apigee_kickstart/templates/node/node--page--full.html.twig
+++ b/themes/custom/apigee_kickstart/templates/node/node--page--full.html.twig
@@ -9,6 +9,7 @@
 
   {% if content.field_header|render %}
     {{ content.field_header }}
+
     {% if tasks|render %}
       <div class="page__tasks">
         <div class="container">
@@ -18,9 +19,11 @@
     {% endif %}
   {% endif %}
 
-  <div class="row pb-7">
-    <div class="col-lg-8">
-      {{ content|without('field_header') }}
+  <div class="container py-5">
+    <div class="row pb-7">
+      <div class="col-lg-8">
+        {{ content|without('field_header') }}
+      </div>
     </div>
   </div>
 

--- a/themes/custom/apigee_kickstart/templates/page/page--node--page.html.twig
+++ b/themes/custom/apigee_kickstart/templates/page/page--node--page.html.twig
@@ -1,0 +1,10 @@
+{#
+/**
+ * @file
+ * Template for an Basic page layout.
+ */
+#}
+{% extends 'page.html.twig' %}
+{% block content %}
+  {{ page.content }}
+{% endblock %}


### PR DESCRIPTION
This PR captures the remaining issues found while working on the documentation screencasts.

## WYSYIWYG Images

Fixes WYSIWYG-uploaded images. The global style for images is `.img-fluid`, which doesn't work for these kinds of images. This PR sets `.img-thumbnail` for images within .text (paragraph), as well as body fields and CKEditor itself, so the images will be contained to a reasonable width regardless of uploaded size.

Before:
<img width="775" alt="wysiwyg-before" src="https://user-images.githubusercontent.com/60979/56431572-2cf02f00-6298-11e9-8fc5-56ca11180916.png">

After:
<img width="769" alt="wysiwyg-after" src="https://user-images.githubusercontent.com/60979/56431574-2d88c580-6298-11e9-968c-4fd37285d986.png">


## Page node Layout

Fixes for page nodes, where a container was being applied, wrapping hero and title bar, which is not wanted.

Before:
<img width="1191" alt="page broken" src="https://user-images.githubusercontent.com/60979/56431349-63797a00-6297-11e9-8341-54b216aa28d1.png">

After:
<img width="1241" alt="page fixed" src="https://user-images.githubusercontent.com/60979/56431350-63797a00-6297-11e9-958c-4af6d163b800.png">


## Alerts

Alerts that appear on pages without a container in `<main>` look bad with a bottom margin. This is resolved by only applying that margin when an alert is within a container.

Before:
<img width="1242" alt="alert broken" src="https://user-images.githubusercontent.com/60979/56431236-0bdb0e80-6297-11e9-8db0-e10026b3ad37.png">

After:
<img width="1246" alt="alert fixed" src="https://user-images.githubusercontent.com/60979/56431141-cc142700-6296-11e9-8e68-34070777dfe4.png">

## Form Displays

Adjustments to Form Display config for Page node, as well as Callout Group, Card Group and Text & Image paragraphs, for consistent editor UX.