### PR TITLE
DRUP-753: Use Apigee Edge released versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "drupal-composer/drupal-scaffold": "^2",
     "drupal/admin_toolbar": "^1.0",
     "drupal/adminimal_admin_toolbar": "^1.9",
-    "drupal/apigee_edge": "1.x-dev",
+    "drupal/apigee_edge": "^1.0",
     "drupal/better_exposed_filters": "^3.0@alpha",
     "drupal/core": "^8.6.0",
     "drupal/default_content": "^1.0@alpha",


### PR DESCRIPTION
The Kickstart project depends on Apigee Edge dev version:

"drupal/apigee_edge": "1.x-dev"

It should use released versions instead.