### PR TITLE
[DRUP-770] Refresh Default Content After 8.7 and default_content@1.0-alpha8 Releases

### DIFF
--- a/modules/custom/apigee_kickstart_content/apigee_kickstart_content.info.yml
+++ b/modules/custom/apigee_kickstart_content/apigee_kickstart_content.info.yml
@@ -7,3 +7,118 @@ dependencies:
   - default_content:default_content
   - drupal:node
   - drupal:block_content
+
+default_content:
+  apidoc:
+    - 3ac4cc37-b791-47ec-be54-8f4ec11af250
+    - 427ddec7-ab43-4cfb-978d-5f0ac8c652ab
+    - 5035fa45-33d8-449e-b0bb-a19958739341
+    - b46d932c-d9bc-4833-b94a-7d751beae0e9
+    - b6174544-26d4-4477-b64f-a72fbc641feb
+    - f6203776-2a93-466e-8d46-2ad078d7e216
+  block_content:
+    - 003ef719-eca7-4ad1-83a3-dc9b403a49b3
+    - 1efa0b42-0ce4-4c67-bd3d-bdb26ed63934
+    - 3c2455a8-2775-4ead-b1ba-c154643da716
+    - 5766af56-5f64-4eb3-81d2-c4c5e4df3f76
+    - 922c5ce8-6d11-4aa6-8d82-542c77b33bec
+    - a94fbb45-8667-451a-b173-cb50cc6faabb
+    - b0b4fd9e-4a0c-4c21-b1b4-77ed6586d40c
+    - bae58a0b-4f55-484f-9ee5-f2ecbf7c715e
+    - c9d29264-1428-4f25-ba78-736d7748459e
+    - de9351da-3424-4401-ba46-64709a9f12d4
+    - ed93a36e-95ee-4bfe-b8db-1d5ae5ae99cb
+  comment:
+    - 0e75f664-a915-487a-a9f8-439d7a148b19
+    - 8dc43422-1def-4457-a331-196b1f41f028
+  file:
+    - 07ffc23c-29a7-4ffb-8322-418f220ccec8
+    - 08759418-466d-4ab8-bcb6-0fee31849e2b
+    - 0e1ac7bf-a77d-42c8-a6af-9026901081f7
+    - 5611795c-f843-4734-a3c7-6ddcdf75ef92
+    - 5825fc44-81dd-4ab2-a7a0-adc789cee7f8
+    - 67087e35-c4e4-4f3b-8757-99a60bc95bb8
+    - 75a9d1ad-6294-42a9-9516-dc5c6623bb9e
+    - 77a93559-7c69-4549-ab40-1f580fe2a89d
+    - b4b50a71-cba2-4892-8558-be221d29b6b0
+    - bbb8163f-bbff-44b0-833c-134a3af276d0
+    - e80f2f09-c967-447f-8b59-ab0388ce79b7
+  media:
+    - 08ad78f2-dcad-403e-8ca6-4c2ae1555216
+    - 39927b68-d6ea-40de-b499-fb46ef663ffb
+    - 7517d587-e652-4a9c-86c3-09ee39db5232
+    - 79f038c1-8e9e-46fb-ac60-8ab17854492a
+    - a763fbf5-2547-401e-88ab-5924b2c4f5cb
+    - e5ef1b62-468c-42be-a305-d0005c029619
+    - e65db5c0-184c-4b38-93b1-1462ac5a39c0
+    - f254c054-c4a1-46ff-80c2-6eff444ce5bd
+    - f3c8694f-bda0-4dec-ae89-0db3e59e8e7a
+  menu_link_content:
+    - 00d028d8-36f3-4758-b644-d4d55f7f0cce
+    - 0dc221ed-fabe-464a-9a09-18e7398952df
+    - 17a960ae-8e88-4f7f-b000-56076f076e95
+  node:
+    - 08dd5a22-1712-41b2-8afb-3623b83d9a74
+    - 092445b5-0f8e-4dc5-a56a-7fa4c5de8136
+    - 1924bd12-dac3-4377-b4e8-daec91f30c1b
+    - 35dc3dd9-205d-4fea-954f-39297c71b50f
+    - 3890114e-688b-4c8e-9a87-e74a22b0e456
+    - 65a93625-1bbb-4e24-b3bd-87c432ecec21
+    - 7c30dc66-b866-4b9d-8351-0de09bee8094
+    - 7fde3835-2c65-4df2-abd4-227eab08098a
+    - 81a691d1-0f93-4374-bb28-c42fc6cc1692
+    - 88696329-c494-40c5-9339-dfaab375f092
+    - 8d66ec13-400c-4c67-b1d2-19d481b7c04e
+    - abc89fd3-4cda-46bb-aa3d-416f5639ef3c
+    - acf16bcc-b4f1-4dc4-8240-ceb98007d2ee
+    - c92c7326-0042-43f0-b37c-e3409141fb8a
+    - e8a69fee-63d5-42fa-9daa-9fd027133276
+    - ff6b399b-96d5-4366-8341-def6a7d25876
+  paragraph:
+    - 020a8340-8fec-44ff-9a2f-fee4fc33856f
+    - 133a8cb0-6813-4a2c-9f8a-a4c7a9109268
+    - 154c0f43-1199-4abe-966c-ad8369154389
+    - 1c7999b0-8818-47d9-9c40-7879106e8ac3
+    - 1e5ed1e2-cc3c-4726-af53-f2be27dd16c4
+    - 338d65b4-8589-47bf-869e-63699ecdefea
+    - 3856ebb8-e361-456b-9997-d92cc39857aa
+    - 403797c9-4f61-4525-bb73-c18e8313fc91
+    - 44d3e172-3034-407a-969f-a028363e3d79
+    - 44faa73c-d977-4f45-b9cb-b2105d862205
+    - 47c17640-c496-4701-85e7-24ccac26692c
+    - 548b6335-4256-4a63-a41f-d2eca4207262
+    - 553bc28b-b818-4e1f-971d-647bb659c880
+    - 5830ad51-7aea-4269-9b6f-e4a2705ec613
+    - 65d6bf7f-d664-446e-9dc7-0909a5161c63
+    - 6962af12-68ad-4d30-a920-19b6a05e269a
+    - 73ec3b20-3b9a-43d1-bbcd-65362abe0fda
+    - 73f553f5-22c9-4528-b85e-e4c1509a0f3d
+    - 747b5e4d-7809-44f5-8de5-eb3b2a854ce2
+    - 7e2cbb90-7928-41dd-9240-09afaa1a14cf
+    - a04cfedd-8aa9-44af-8f1f-cb21e0363799
+    - a84a1787-a271-4991-b8b0-d6a0065f0ede
+    - a88f5f35-7e4b-4d81-9ce1-b8c5170f2abd
+    - aa785a70-635e-4673-abd0-7385d3596800
+    - ac433a9f-377b-49b7-95ee-3616cda19902
+    - add26ffc-d4b5-4c7f-9613-826ce477ee05
+    - b1e0a232-04b4-44fe-b211-3de506cfea1a
+    - bf056947-7a1b-4f33-9e6f-501b36a38761
+    - bfc557df-811a-4c61-88ee-f9eba6f86c07
+    - c1e17d1a-4f2e-4376-8057-01c67cabf555
+    - df395751-d7f6-4dbe-88cb-7759e346cb0c
+    - e17133e2-31c0-4c7b-8e59-6c3f75524c03
+    - e1e76a11-29fe-48b1-a729-f33e8de6ce17
+    - e5f4469f-0ac1-4771-8f0c-7ba19d41db87
+    - ecbc1c18-156a-4fe4-90e5-f4db4cce8bc4
+    - ffcb3485-4182-416c-bb0c-0f3875a203e2
+  taxonomy_term:
+    - 14aca1e1-227d-4a96-b340-9910f4ff087c
+    - 21610fde-d521-4f1b-b56f-63cdee1aec2a
+    - 40d3bba3-edec-4794-9481-3c4e21cdd396
+    - 53652a5b-1721-414f-b30b-ee13a8ea06a6
+    - 5869a2b7-3d46-4cfe-b2c7-59044b86c06a
+    - 82a2a2ab-741c-4331-9ee5-211c8d4fd5cf
+    - a09a32c1-fa1f-403b-888c-e02616998419
+    - a63cae7c-c969-487a-a6f5-6a66a045c447
+    - b96f6867-e1a8-4bdf-a8dd-ec61a47d100b
+    - c5e62e4a-18c3-4d91-83aa-db55e16c48a6

--- a/modules/custom/apigee_kickstart_content/content/apidoc/3ac4cc37-b791-47ec-be54-8f4ec11af250.json
+++ b/modules/custom/apigee_kickstart_content/content/apidoc/3ac4cc37-b791-47ec-be54-8f4ec11af250.json
@@ -18,7 +18,7 @@
         ],
         "http:\/\/drupal.org\/rest\/relation\/apidoc\/apidoc\/field_image": [
             {
-                "href": "http:\/\/default\/media\/6?_format=hal_json"
+                "href": "http:\/\/default\/media\/6\/edit?_format=hal_json"
             }
         ]
     },
@@ -89,7 +89,7 @@
             {
                 "_links": {
                     "self": {
-                        "href": "http:\/\/default\/media\/6?_format=hal_json"
+                        "href": "http:\/\/default\/media\/6\/edit?_format=hal_json"
                     },
                     "type": {
                         "href": "http:\/\/drupal.org\/rest\/type\/media\/image"

--- a/modules/custom/apigee_kickstart_content/content/apidoc/427ddec7-ab43-4cfb-978d-5f0ac8c652ab.json
+++ b/modules/custom/apigee_kickstart_content/content/apidoc/427ddec7-ab43-4cfb-978d-5f0ac8c652ab.json
@@ -18,7 +18,7 @@
         ],
         "http:\/\/drupal.org\/rest\/relation\/apidoc\/apidoc\/field_image": [
             {
-                "href": "http:\/\/default\/media\/5?_format=hal_json"
+                "href": "http:\/\/default\/media\/5\/edit?_format=hal_json"
             }
         ]
     },
@@ -89,7 +89,7 @@
             {
                 "_links": {
                     "self": {
-                        "href": "http:\/\/default\/media\/5?_format=hal_json"
+                        "href": "http:\/\/default\/media\/5\/edit?_format=hal_json"
                     },
                     "type": {
                         "href": "http:\/\/drupal.org\/rest\/type\/media\/image"

--- a/modules/custom/apigee_kickstart_content/content/apidoc/5035fa45-33d8-449e-b0bb-a19958739341.json
+++ b/modules/custom/apigee_kickstart_content/content/apidoc/5035fa45-33d8-449e-b0bb-a19958739341.json
@@ -18,7 +18,7 @@
         ],
         "http:\/\/drupal.org\/rest\/relation\/apidoc\/apidoc\/field_image": [
             {
-                "href": "http:\/\/default\/media\/5?_format=hal_json"
+                "href": "http:\/\/default\/media\/5\/edit?_format=hal_json"
             }
         ]
     },
@@ -89,7 +89,7 @@
             {
                 "_links": {
                     "self": {
-                        "href": "http:\/\/default\/media\/5?_format=hal_json"
+                        "href": "http:\/\/default\/media\/5\/edit?_format=hal_json"
                     },
                     "type": {
                         "href": "http:\/\/drupal.org\/rest\/type\/media\/image"

--- a/modules/custom/apigee_kickstart_content/content/apidoc/b46d932c-d9bc-4833-b94a-7d751beae0e9.json
+++ b/modules/custom/apigee_kickstart_content/content/apidoc/b46d932c-d9bc-4833-b94a-7d751beae0e9.json
@@ -21,7 +21,7 @@
         ],
         "http:\/\/drupal.org\/rest\/relation\/apidoc\/apidoc\/field_image": [
             {
-                "href": "http:\/\/default\/media\/3?_format=hal_json"
+                "href": "http:\/\/default\/media\/3\/edit?_format=hal_json"
             }
         ]
     },
@@ -107,7 +107,7 @@
             {
                 "_links": {
                     "self": {
-                        "href": "http:\/\/default\/media\/3?_format=hal_json"
+                        "href": "http:\/\/default\/media\/3\/edit?_format=hal_json"
                     },
                     "type": {
                         "href": "http:\/\/drupal.org\/rest\/type\/media\/image"

--- a/modules/custom/apigee_kickstart_content/content/apidoc/b6174544-26d4-4477-b64f-a72fbc641feb.json
+++ b/modules/custom/apigee_kickstart_content/content/apidoc/b6174544-26d4-4477-b64f-a72fbc641feb.json
@@ -21,7 +21,7 @@
         ],
         "http:\/\/drupal.org\/rest\/relation\/apidoc\/apidoc\/field_image": [
             {
-                "href": "http:\/\/default\/media\/7?_format=hal_json"
+                "href": "http:\/\/default\/media\/7\/edit?_format=hal_json"
             }
         ]
     },
@@ -107,7 +107,7 @@
             {
                 "_links": {
                     "self": {
-                        "href": "http:\/\/default\/media\/7?_format=hal_json"
+                        "href": "http:\/\/default\/media\/7\/edit?_format=hal_json"
                     },
                     "type": {
                         "href": "http:\/\/drupal.org\/rest\/type\/media\/image"

--- a/modules/custom/apigee_kickstart_content/content/apidoc/f6203776-2a93-466e-8d46-2ad078d7e216.json
+++ b/modules/custom/apigee_kickstart_content/content/apidoc/f6203776-2a93-466e-8d46-2ad078d7e216.json
@@ -21,7 +21,7 @@
         ],
         "http:\/\/drupal.org\/rest\/relation\/apidoc\/apidoc\/field_image": [
             {
-                "href": "http:\/\/default\/media\/2?_format=hal_json"
+                "href": "http:\/\/default\/media\/2\/edit?_format=hal_json"
             }
         ]
     },
@@ -107,7 +107,7 @@
             {
                 "_links": {
                     "self": {
-                        "href": "http:\/\/default\/media\/2?_format=hal_json"
+                        "href": "http:\/\/default\/media\/2\/edit?_format=hal_json"
                     },
                     "type": {
                         "href": "http:\/\/drupal.org\/rest\/type\/media\/image"

--- a/modules/custom/apigee_kickstart_content/content/block_content/1efa0b42-0ce4-4c67-bd3d-bdb26ed63934.json
+++ b/modules/custom/apigee_kickstart_content/content/block_content/1efa0b42-0ce4-4c67-bd3d-bdb26ed63934.json
@@ -6,11 +6,6 @@
         "type": {
             "href": "http:\/\/drupal.org\/rest\/type\/block_content\/title_bar"
         },
-        "http:\/\/drupal.org\/rest\/relation\/block_content\/title_bar\/revision_user": [
-            {
-                "href": "http:\/\/default\/user\/1?_format=hal_json"
-            }
-        ],
         "http:\/\/drupal.org\/rest\/relation\/block_content\/title_bar\/field_title_bar": [
             {
                 "href": "",
@@ -50,44 +45,6 @@
             "format": "Y-m-d\\TH:i:sP"
         }
     ],
-    "_embedded": {
-        "http:\/\/drupal.org\/rest\/relation\/block_content\/title_bar\/revision_user": [
-            {
-                "_links": {
-                    "self": {
-                        "href": "http:\/\/default\/user\/1?_format=hal_json"
-                    },
-                    "type": {
-                        "href": "http:\/\/drupal.org\/rest\/type\/user\/user"
-                    }
-                },
-                "uuid": [
-                    {
-                        "value": "3c6e9a68-6fda-49a9-9164-f6717cfc1cff"
-                    }
-                ]
-            }
-        ],
-        "http:\/\/drupal.org\/rest\/relation\/block_content\/title_bar\/field_title_bar": [
-            {
-                "_links": {
-                    "self": {
-                        "href": ""
-                    },
-                    "type": {
-                        "href": "http:\/\/drupal.org\/rest\/type\/paragraph\/title_bar"
-                    }
-                },
-                "uuid": [
-                    {
-                        "value": "add26ffc-d4b5-4c7f-9613-826ce477ee05"
-                    }
-                ],
-                "lang": "en",
-                "target_revision_id": "182"
-            }
-        ]
-    },
     "status": [
         {
             "value": true,
@@ -123,5 +80,26 @@
             "value": true,
             "lang": "en"
         }
-    ]
+    ],
+    "_embedded": {
+        "http:\/\/drupal.org\/rest\/relation\/block_content\/title_bar\/field_title_bar": [
+            {
+                "_links": {
+                    "self": {
+                        "href": ""
+                    },
+                    "type": {
+                        "href": "http:\/\/drupal.org\/rest\/type\/paragraph\/title_bar"
+                    }
+                },
+                "uuid": [
+                    {
+                        "value": "add26ffc-d4b5-4c7f-9613-826ce477ee05"
+                    }
+                ],
+                "lang": "en",
+                "target_revision_id": "182"
+            }
+        ]
+    }
 }

--- a/modules/custom/apigee_kickstart_content/content/comment/0e75f664-a915-487a-a9f8-439d7a148b19.json
+++ b/modules/custom/apigee_kickstart_content/content/comment/0e75f664-a915-487a-a9f8-439d7a148b19.json
@@ -6,15 +6,15 @@
         "type": {
             "href": "http:\/\/drupal.org\/rest\/type\/comment\/comment_forum"
         },
-        "http:\/\/drupal.org\/rest\/relation\/comment\/comment_forum\/entity_id": [
-            {
-                "href": "http:\/\/default\/forum\/security-tokens-documentation?_format=hal_json"
-            }
-        ],
         "http:\/\/drupal.org\/rest\/relation\/comment\/comment_forum\/uid": [
             {
                 "href": "http:\/\/default\/user\/1?_format=hal_json",
                 "lang": "en"
+            }
+        ],
+        "http:\/\/drupal.org\/rest\/relation\/comment\/comment_forum\/entity_id": [
+            {
+                "href": "http:\/\/default\/forum\/security-tokens-documentation?_format=hal_json"
             }
         ]
     },
@@ -46,6 +46,24 @@
         }
     ],
     "_embedded": {
+        "http:\/\/drupal.org\/rest\/relation\/comment\/comment_forum\/uid": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "http:\/\/default\/user\/1?_format=hal_json"
+                    },
+                    "type": {
+                        "href": "http:\/\/drupal.org\/rest\/type\/user\/user"
+                    }
+                },
+                "uuid": [
+                    {
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
+                    }
+                ],
+                "lang": "en"
+            }
+        ],
         "http:\/\/drupal.org\/rest\/relation\/comment\/comment_forum\/entity_id": [
             {
                 "_links": {
@@ -61,24 +79,6 @@
                         "value": "08dd5a22-1712-41b2-8afb-3623b83d9a74"
                     }
                 ]
-            }
-        ],
-        "http:\/\/drupal.org\/rest\/relation\/comment\/comment_forum\/uid": [
-            {
-                "_links": {
-                    "self": {
-                        "href": "http:\/\/default\/user\/1?_format=hal_json"
-                    },
-                    "type": {
-                        "href": "http:\/\/drupal.org\/rest\/type\/user\/user"
-                    }
-                },
-                "uuid": [
-                    {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
-                    }
-                ],
-                "lang": "en"
             }
         ]
     },

--- a/modules/custom/apigee_kickstart_content/content/comment/8dc43422-1def-4457-a331-196b1f41f028.json
+++ b/modules/custom/apigee_kickstart_content/content/comment/8dc43422-1def-4457-a331-196b1f41f028.json
@@ -6,15 +6,15 @@
         "type": {
             "href": "http:\/\/drupal.org\/rest\/type\/comment\/comment"
         },
-        "http:\/\/drupal.org\/rest\/relation\/comment\/comment\/entity_id": [
-            {
-                "href": "http:\/\/default\/article\/pretium-viverra-suspendisse-potenti-fermentum?_format=hal_json"
-            }
-        ],
         "http:\/\/drupal.org\/rest\/relation\/comment\/comment\/uid": [
             {
                 "href": "http:\/\/default\/user\/1?_format=hal_json",
                 "lang": "en"
+            }
+        ],
+        "http:\/\/drupal.org\/rest\/relation\/comment\/comment\/entity_id": [
+            {
+                "href": "http:\/\/default\/article\/pretium-viverra-suspendisse-potenti-fermentum?_format=hal_json"
             }
         ]
     },
@@ -46,6 +46,24 @@
         }
     ],
     "_embedded": {
+        "http:\/\/drupal.org\/rest\/relation\/comment\/comment\/uid": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "http:\/\/default\/user\/1?_format=hal_json"
+                    },
+                    "type": {
+                        "href": "http:\/\/drupal.org\/rest\/type\/user\/user"
+                    }
+                },
+                "uuid": [
+                    {
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
+                    }
+                ],
+                "lang": "en"
+            }
+        ],
         "http:\/\/drupal.org\/rest\/relation\/comment\/comment\/entity_id": [
             {
                 "_links": {
@@ -61,24 +79,6 @@
                         "value": "abc89fd3-4cda-46bb-aa3d-416f5639ef3c"
                     }
                 ]
-            }
-        ],
-        "http:\/\/drupal.org\/rest\/relation\/comment\/comment\/uid": [
-            {
-                "_links": {
-                    "self": {
-                        "href": "http:\/\/default\/user\/1?_format=hal_json"
-                    },
-                    "type": {
-                        "href": "http:\/\/drupal.org\/rest\/type\/user\/user"
-                    }
-                },
-                "uuid": [
-                    {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
-                    }
-                ],
-                "lang": "en"
             }
         ]
     },

--- a/modules/custom/apigee_kickstart_content/content/file/07ffc23c-29a7-4ffb-8322-418f220ccec8.json
+++ b/modules/custom/apigee_kickstart_content/content/file/07ffc23c-29a7-4ffb-8322-418f220ccec8.json
@@ -40,7 +40,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }

--- a/modules/custom/apigee_kickstart_content/content/file/08759418-466d-4ab8-bcb6-0fee31849e2b.json
+++ b/modules/custom/apigee_kickstart_content/content/file/08759418-466d-4ab8-bcb6-0fee31849e2b.json
@@ -40,7 +40,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }

--- a/modules/custom/apigee_kickstart_content/content/file/0e1ac7bf-a77d-42c8-a6af-9026901081f7.json
+++ b/modules/custom/apigee_kickstart_content/content/file/0e1ac7bf-a77d-42c8-a6af-9026901081f7.json
@@ -40,7 +40,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }

--- a/modules/custom/apigee_kickstart_content/content/file/5611795c-f843-4734-a3c7-6ddcdf75ef92.json
+++ b/modules/custom/apigee_kickstart_content/content/file/5611795c-f843-4734-a3c7-6ddcdf75ef92.json
@@ -40,7 +40,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }

--- a/modules/custom/apigee_kickstart_content/content/file/5825fc44-81dd-4ab2-a7a0-adc789cee7f8.json
+++ b/modules/custom/apigee_kickstart_content/content/file/5825fc44-81dd-4ab2-a7a0-adc789cee7f8.json
@@ -40,7 +40,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }

--- a/modules/custom/apigee_kickstart_content/content/file/67087e35-c4e4-4f3b-8757-99a60bc95bb8.json
+++ b/modules/custom/apigee_kickstart_content/content/file/67087e35-c4e4-4f3b-8757-99a60bc95bb8.json
@@ -40,7 +40,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }

--- a/modules/custom/apigee_kickstart_content/content/file/75a9d1ad-6294-42a9-9516-dc5c6623bb9e.json
+++ b/modules/custom/apigee_kickstart_content/content/file/75a9d1ad-6294-42a9-9516-dc5c6623bb9e.json
@@ -40,7 +40,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }

--- a/modules/custom/apigee_kickstart_content/content/file/77a93559-7c69-4549-ab40-1f580fe2a89d.json
+++ b/modules/custom/apigee_kickstart_content/content/file/77a93559-7c69-4549-ab40-1f580fe2a89d.json
@@ -40,7 +40,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }

--- a/modules/custom/apigee_kickstart_content/content/file/b4b50a71-cba2-4892-8558-be221d29b6b0.json
+++ b/modules/custom/apigee_kickstart_content/content/file/b4b50a71-cba2-4892-8558-be221d29b6b0.json
@@ -40,7 +40,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }

--- a/modules/custom/apigee_kickstart_content/content/file/bbb8163f-bbff-44b0-833c-134a3af276d0.json
+++ b/modules/custom/apigee_kickstart_content/content/file/bbb8163f-bbff-44b0-833c-134a3af276d0.json
@@ -40,7 +40,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }

--- a/modules/custom/apigee_kickstart_content/content/file/e80f2f09-c967-447f-8b59-ab0388ce79b7.json
+++ b/modules/custom/apigee_kickstart_content/content/file/e80f2f09-c967-447f-8b59-ab0388ce79b7.json
@@ -40,7 +40,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }

--- a/modules/custom/apigee_kickstart_content/content/media/08ad78f2-dcad-403e-8ca6-4c2ae1555216.json
+++ b/modules/custom/apigee_kickstart_content/content/media/08ad78f2-dcad-403e-8ca6-4c2ae1555216.json
@@ -1,20 +1,20 @@
 {
     "_links": {
         "self": {
-            "href": "http:\/\/default\/media\/9?_format=hal_json"
+            "href": "http:\/\/default\/media\/9\/edit?_format=hal_json"
         },
         "type": {
             "href": "http:\/\/drupal.org\/rest\/type\/media\/image"
         },
-        "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
-            {
-                "href": "http:\/\/default\/sites\/default\/files\/chuttersnap-255216-unsplash.png",
-                "lang": "en"
-            }
-        ],
         "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
             {
                 "href": "http:\/\/default\/user\/1?_format=hal_json",
+                "lang": "en"
+            }
+        ],
+        "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
+            {
+                "href": "http:\/\/default\/sites\/default\/files\/chuttersnap-255216-unsplash.png",
                 "lang": "en"
             }
         ],
@@ -53,7 +53,7 @@
     ],
     "revision_created": [
         {
-            "value": "2019-04-10T13:59:54+00:00",
+            "value": "2019-05-08T14:50:16+00:00",
             "format": "Y-m-d\\TH:i:sP"
         }
     ],
@@ -63,13 +63,25 @@
             "lang": "en"
         }
     ],
-    "name": [
-        {
-            "value": "chuttersnap-255216-unsplash.png",
-            "lang": "en"
-        }
-    ],
     "_embedded": {
+        "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "http:\/\/default\/user\/1?_format=hal_json"
+                    },
+                    "type": {
+                        "href": "http:\/\/drupal.org\/rest\/type\/user\/user"
+                    }
+                },
+                "uuid": [
+                    {
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
+                    }
+                ],
+                "lang": "en"
+            }
+        ],
         "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
             {
                 "_links": {
@@ -83,24 +95,6 @@
                 "uuid": [
                     {
                         "value": "5825fc44-81dd-4ab2-a7a0-adc789cee7f8"
-                    }
-                ],
-                "lang": "en"
-            }
-        ],
-        "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
-            {
-                "_links": {
-                    "self": {
-                        "href": "http:\/\/default\/user\/1?_format=hal_json"
-                    },
-                    "type": {
-                        "href": "http:\/\/drupal.org\/rest\/type\/user\/user"
-                    }
-                },
-                "uuid": [
-                    {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
                     }
                 ],
                 "lang": "en"
@@ -125,6 +119,12 @@
             }
         ]
     },
+    "name": [
+        {
+            "value": "chuttersnap-255216-unsplash.png",
+            "lang": "en"
+        }
+    ],
     "created": [
         {
             "value": "2019-04-10T13:33:10+00:00",

--- a/modules/custom/apigee_kickstart_content/content/media/39927b68-d6ea-40de-b499-fb46ef663ffb.json
+++ b/modules/custom/apigee_kickstart_content/content/media/39927b68-d6ea-40de-b499-fb46ef663ffb.json
@@ -1,20 +1,20 @@
 {
     "_links": {
         "self": {
-            "href": "http:\/\/default\/media\/8?_format=hal_json"
+            "href": "http:\/\/default\/media\/8\/edit?_format=hal_json"
         },
         "type": {
             "href": "http:\/\/drupal.org\/rest\/type\/media\/image"
         },
-        "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
-            {
-                "href": "http:\/\/default\/sites\/default\/files\/nasa-43567-unsplash.jpg",
-                "lang": "en"
-            }
-        ],
         "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
             {
                 "href": "http:\/\/default\/user\/1?_format=hal_json",
+                "lang": "en"
+            }
+        ],
+        "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
+            {
+                "href": "http:\/\/default\/sites\/default\/files\/nasa-43567-unsplash.jpg",
                 "lang": "en"
             }
         ],
@@ -53,7 +53,7 @@
     ],
     "revision_created": [
         {
-            "value": "2019-04-04T02:12:42+00:00",
+            "value": "2019-05-08T14:50:16+00:00",
             "format": "Y-m-d\\TH:i:sP"
         }
     ],
@@ -63,13 +63,25 @@
             "lang": "en"
         }
     ],
-    "name": [
-        {
-            "value": "nasa-43567-unsplash.jpg",
-            "lang": "en"
-        }
-    ],
     "_embedded": {
+        "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "http:\/\/default\/user\/1?_format=hal_json"
+                    },
+                    "type": {
+                        "href": "http:\/\/drupal.org\/rest\/type\/user\/user"
+                    }
+                },
+                "uuid": [
+                    {
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
+                    }
+                ],
+                "lang": "en"
+            }
+        ],
         "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
             {
                 "_links": {
@@ -83,24 +95,6 @@
                 "uuid": [
                     {
                         "value": "77a93559-7c69-4549-ab40-1f580fe2a89d"
-                    }
-                ],
-                "lang": "en"
-            }
-        ],
-        "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
-            {
-                "_links": {
-                    "self": {
-                        "href": "http:\/\/default\/user\/1?_format=hal_json"
-                    },
-                    "type": {
-                        "href": "http:\/\/drupal.org\/rest\/type\/user\/user"
-                    }
-                },
-                "uuid": [
-                    {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
                     }
                 ],
                 "lang": "en"
@@ -125,6 +119,12 @@
             }
         ]
     },
+    "name": [
+        {
+            "value": "nasa-43567-unsplash.jpg",
+            "lang": "en"
+        }
+    ],
     "created": [
         {
             "value": "2019-03-17T03:51:55+00:00",

--- a/modules/custom/apigee_kickstart_content/content/media/7517d587-e652-4a9c-86c3-09ee39db5232.json
+++ b/modules/custom/apigee_kickstart_content/content/media/7517d587-e652-4a9c-86c3-09ee39db5232.json
@@ -1,20 +1,20 @@
 {
     "_links": {
         "self": {
-            "href": "http:\/\/default\/media\/5?_format=hal_json"
+            "href": "http:\/\/default\/media\/5\/edit?_format=hal_json"
         },
         "type": {
             "href": "http:\/\/drupal.org\/rest\/type\/media\/image"
         },
-        "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
-            {
-                "href": "http:\/\/default\/sites\/default\/files\/aditya-vyas-1392552-unsplash.jpg",
-                "lang": "en"
-            }
-        ],
         "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
             {
                 "href": "http:\/\/default\/user\/1?_format=hal_json",
+                "lang": "en"
+            }
+        ],
+        "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
+            {
+                "href": "http:\/\/default\/sites\/default\/files\/aditya-vyas-1392552-unsplash.jpg",
                 "lang": "en"
             }
         ],
@@ -53,7 +53,7 @@
     ],
     "revision_created": [
         {
-            "value": "2019-04-10T13:59:54+00:00",
+            "value": "2019-05-08T14:50:16+00:00",
             "format": "Y-m-d\\TH:i:sP"
         }
     ],
@@ -63,13 +63,25 @@
             "lang": "en"
         }
     ],
-    "name": [
-        {
-            "value": "aditya-vyas-1392552-unsplash.jpg",
-            "lang": "en"
-        }
-    ],
     "_embedded": {
+        "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "http:\/\/default\/user\/1?_format=hal_json"
+                    },
+                    "type": {
+                        "href": "http:\/\/drupal.org\/rest\/type\/user\/user"
+                    }
+                },
+                "uuid": [
+                    {
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
+                    }
+                ],
+                "lang": "en"
+            }
+        ],
         "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
             {
                 "_links": {
@@ -83,24 +95,6 @@
                 "uuid": [
                     {
                         "value": "08759418-466d-4ab8-bcb6-0fee31849e2b"
-                    }
-                ],
-                "lang": "en"
-            }
-        ],
-        "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
-            {
-                "_links": {
-                    "self": {
-                        "href": "http:\/\/default\/user\/1?_format=hal_json"
-                    },
-                    "type": {
-                        "href": "http:\/\/drupal.org\/rest\/type\/user\/user"
-                    }
-                },
-                "uuid": [
-                    {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
                     }
                 ],
                 "lang": "en"
@@ -125,6 +119,12 @@
             }
         ]
     },
+    "name": [
+        {
+            "value": "aditya-vyas-1392552-unsplash.jpg",
+            "lang": "en"
+        }
+    ],
     "created": [
         {
             "value": "2019-03-15T18:59:44+00:00",

--- a/modules/custom/apigee_kickstart_content/content/media/79f038c1-8e9e-46fb-ac60-8ab17854492a.json
+++ b/modules/custom/apigee_kickstart_content/content/media/79f038c1-8e9e-46fb-ac60-8ab17854492a.json
@@ -1,20 +1,20 @@
 {
     "_links": {
         "self": {
-            "href": "http:\/\/default\/media\/4?_format=hal_json"
+            "href": "http:\/\/default\/media\/4\/edit?_format=hal_json"
         },
         "type": {
             "href": "http:\/\/drupal.org\/rest\/type\/media\/image"
         },
-        "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
-            {
-                "href": "http:\/\/default\/sites\/default\/files\/spacex-81773-unsplash.jpg",
-                "lang": "en"
-            }
-        ],
         "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
             {
                 "href": "http:\/\/default\/user\/1?_format=hal_json",
+                "lang": "en"
+            }
+        ],
+        "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
+            {
+                "href": "http:\/\/default\/sites\/default\/files\/spacex-81773-unsplash.jpg",
                 "lang": "en"
             }
         ],
@@ -53,7 +53,7 @@
     ],
     "revision_created": [
         {
-            "value": "2019-04-10T13:59:54+00:00",
+            "value": "2019-05-08T14:50:16+00:00",
             "format": "Y-m-d\\TH:i:sP"
         }
     ],
@@ -63,13 +63,25 @@
             "lang": "en"
         }
     ],
-    "name": [
-        {
-            "value": "spacex-81773-unsplash.jpg",
-            "lang": "en"
-        }
-    ],
     "_embedded": {
+        "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "http:\/\/default\/user\/1?_format=hal_json"
+                    },
+                    "type": {
+                        "href": "http:\/\/drupal.org\/rest\/type\/user\/user"
+                    }
+                },
+                "uuid": [
+                    {
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
+                    }
+                ],
+                "lang": "en"
+            }
+        ],
         "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
             {
                 "_links": {
@@ -83,24 +95,6 @@
                 "uuid": [
                     {
                         "value": "e80f2f09-c967-447f-8b59-ab0388ce79b7"
-                    }
-                ],
-                "lang": "en"
-            }
-        ],
-        "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
-            {
-                "_links": {
-                    "self": {
-                        "href": "http:\/\/default\/user\/1?_format=hal_json"
-                    },
-                    "type": {
-                        "href": "http:\/\/drupal.org\/rest\/type\/user\/user"
-                    }
-                },
-                "uuid": [
-                    {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
                     }
                 ],
                 "lang": "en"
@@ -125,6 +119,12 @@
             }
         ]
     },
+    "name": [
+        {
+            "value": "spacex-81773-unsplash.jpg",
+            "lang": "en"
+        }
+    ],
     "created": [
         {
             "value": "2019-03-15T18:50:03+00:00",

--- a/modules/custom/apigee_kickstart_content/content/media/a763fbf5-2547-401e-88ab-5924b2c4f5cb.json
+++ b/modules/custom/apigee_kickstart_content/content/media/a763fbf5-2547-401e-88ab-5924b2c4f5cb.json
@@ -1,20 +1,20 @@
 {
     "_links": {
         "self": {
-            "href": "http:\/\/default\/media\/6?_format=hal_json"
+            "href": "http:\/\/default\/media\/6\/edit?_format=hal_json"
         },
         "type": {
             "href": "http:\/\/drupal.org\/rest\/type\/media\/image"
         },
-        "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
-            {
-                "href": "http:\/\/default\/sites\/default\/files\/terence-burke-1417892-unsplash.jpg",
-                "lang": "en"
-            }
-        ],
         "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
             {
                 "href": "http:\/\/default\/user\/1?_format=hal_json",
+                "lang": "en"
+            }
+        ],
+        "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
+            {
+                "href": "http:\/\/default\/sites\/default\/files\/terence-burke-1417892-unsplash.jpg",
                 "lang": "en"
             }
         ],
@@ -53,7 +53,7 @@
     ],
     "revision_created": [
         {
-            "value": "2019-04-04T02:12:42+00:00",
+            "value": "2019-05-08T14:50:16+00:00",
             "format": "Y-m-d\\TH:i:sP"
         }
     ],
@@ -63,13 +63,25 @@
             "lang": "en"
         }
     ],
-    "name": [
-        {
-            "value": "terence-burke-1417892-unsplash.jpg",
-            "lang": "en"
-        }
-    ],
     "_embedded": {
+        "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "http:\/\/default\/user\/1?_format=hal_json"
+                    },
+                    "type": {
+                        "href": "http:\/\/drupal.org\/rest\/type\/user\/user"
+                    }
+                },
+                "uuid": [
+                    {
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
+                    }
+                ],
+                "lang": "en"
+            }
+        ],
         "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
             {
                 "_links": {
@@ -83,24 +95,6 @@
                 "uuid": [
                     {
                         "value": "b4b50a71-cba2-4892-8558-be221d29b6b0"
-                    }
-                ],
-                "lang": "en"
-            }
-        ],
-        "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
-            {
-                "_links": {
-                    "self": {
-                        "href": "http:\/\/default\/user\/1?_format=hal_json"
-                    },
-                    "type": {
-                        "href": "http:\/\/drupal.org\/rest\/type\/user\/user"
-                    }
-                },
-                "uuid": [
-                    {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
                     }
                 ],
                 "lang": "en"
@@ -125,6 +119,12 @@
             }
         ]
     },
+    "name": [
+        {
+            "value": "terence-burke-1417892-unsplash.jpg",
+            "lang": "en"
+        }
+    ],
     "created": [
         {
             "value": "2019-03-17T03:27:04+00:00",

--- a/modules/custom/apigee_kickstart_content/content/media/e5ef1b62-468c-42be-a305-d0005c029619.json
+++ b/modules/custom/apigee_kickstart_content/content/media/e5ef1b62-468c-42be-a305-d0005c029619.json
@@ -1,20 +1,20 @@
 {
     "_links": {
         "self": {
-            "href": "http:\/\/default\/media\/3?_format=hal_json"
+            "href": "http:\/\/default\/media\/3\/edit?_format=hal_json"
         },
         "type": {
             "href": "http:\/\/drupal.org\/rest\/type\/media\/image"
         },
-        "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
-            {
-                "href": "http:\/\/default\/sites\/default\/files\/nasa-89116-unsplash.jpg",
-                "lang": "en"
-            }
-        ],
         "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
             {
                 "href": "http:\/\/default\/user\/1?_format=hal_json",
+                "lang": "en"
+            }
+        ],
+        "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
+            {
+                "href": "http:\/\/default\/sites\/default\/files\/nasa-89116-unsplash.jpg",
                 "lang": "en"
             }
         ],
@@ -53,7 +53,7 @@
     ],
     "revision_created": [
         {
-            "value": "2019-04-10T13:59:54+00:00",
+            "value": "2019-05-08T14:50:16+00:00",
             "format": "Y-m-d\\TH:i:sP"
         }
     ],
@@ -63,13 +63,25 @@
             "lang": "en"
         }
     ],
-    "name": [
-        {
-            "value": "nasa-89116-unsplash.jpg",
-            "lang": "en"
-        }
-    ],
     "_embedded": {
+        "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "http:\/\/default\/user\/1?_format=hal_json"
+                    },
+                    "type": {
+                        "href": "http:\/\/drupal.org\/rest\/type\/user\/user"
+                    }
+                },
+                "uuid": [
+                    {
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
+                    }
+                ],
+                "lang": "en"
+            }
+        ],
         "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
             {
                 "_links": {
@@ -83,24 +95,6 @@
                 "uuid": [
                     {
                         "value": "67087e35-c4e4-4f3b-8757-99a60bc95bb8"
-                    }
-                ],
-                "lang": "en"
-            }
-        ],
-        "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
-            {
-                "_links": {
-                    "self": {
-                        "href": "http:\/\/default\/user\/1?_format=hal_json"
-                    },
-                    "type": {
-                        "href": "http:\/\/drupal.org\/rest\/type\/user\/user"
-                    }
-                },
-                "uuid": [
-                    {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
                     }
                 ],
                 "lang": "en"
@@ -125,6 +119,12 @@
             }
         ]
     },
+    "name": [
+        {
+            "value": "nasa-89116-unsplash.jpg",
+            "lang": "en"
+        }
+    ],
     "created": [
         {
             "value": "2019-03-15T18:48:27+00:00",

--- a/modules/custom/apigee_kickstart_content/content/media/e65db5c0-184c-4b38-93b1-1462ac5a39c0.json
+++ b/modules/custom/apigee_kickstart_content/content/media/e65db5c0-184c-4b38-93b1-1462ac5a39c0.json
@@ -1,20 +1,20 @@
 {
     "_links": {
         "self": {
-            "href": "http:\/\/default\/media\/1?_format=hal_json"
+            "href": "http:\/\/default\/media\/1\/edit?_format=hal_json"
         },
         "type": {
             "href": "http:\/\/drupal.org\/rest\/type\/media\/image"
         },
-        "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
-            {
-                "href": "http:\/\/default\/sites\/default\/files\/spacex-1130896-unsplash.jpg",
-                "lang": "en"
-            }
-        ],
         "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
             {
                 "href": "http:\/\/default\/user\/1?_format=hal_json",
+                "lang": "en"
+            }
+        ],
+        "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
+            {
+                "href": "http:\/\/default\/sites\/default\/files\/spacex-1130896-unsplash.jpg",
                 "lang": "en"
             }
         ],
@@ -53,7 +53,7 @@
     ],
     "revision_created": [
         {
-            "value": "2019-04-04T02:12:42+00:00",
+            "value": "2019-05-08T14:50:16+00:00",
             "format": "Y-m-d\\TH:i:sP"
         }
     ],
@@ -68,13 +68,25 @@
             "lang": "en"
         }
     ],
-    "name": [
-        {
-            "value": "SpaceX Launch",
-            "lang": "en"
-        }
-    ],
     "_embedded": {
+        "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "http:\/\/default\/user\/1?_format=hal_json"
+                    },
+                    "type": {
+                        "href": "http:\/\/drupal.org\/rest\/type\/user\/user"
+                    }
+                },
+                "uuid": [
+                    {
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
+                    }
+                ],
+                "lang": "en"
+            }
+        ],
         "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
             {
                 "_links": {
@@ -88,24 +100,6 @@
                 "uuid": [
                     {
                         "value": "bbb8163f-bbff-44b0-833c-134a3af276d0"
-                    }
-                ],
-                "lang": "en"
-            }
-        ],
-        "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
-            {
-                "_links": {
-                    "self": {
-                        "href": "http:\/\/default\/user\/1?_format=hal_json"
-                    },
-                    "type": {
-                        "href": "http:\/\/drupal.org\/rest\/type\/user\/user"
-                    }
-                },
-                "uuid": [
-                    {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
                     }
                 ],
                 "lang": "en"
@@ -130,6 +124,12 @@
             }
         ]
     },
+    "name": [
+        {
+            "value": "SpaceX Launch",
+            "lang": "en"
+        }
+    ],
     "created": [
         {
             "value": "2019-03-15T17:01:32+00:00",

--- a/modules/custom/apigee_kickstart_content/content/media/f254c054-c4a1-46ff-80c2-6eff444ce5bd.json
+++ b/modules/custom/apigee_kickstart_content/content/media/f254c054-c4a1-46ff-80c2-6eff444ce5bd.json
@@ -1,20 +1,20 @@
 {
     "_links": {
         "self": {
-            "href": "http:\/\/default\/media\/2?_format=hal_json"
+            "href": "http:\/\/default\/media\/2\/edit?_format=hal_json"
         },
         "type": {
             "href": "http:\/\/drupal.org\/rest\/type\/media\/image"
         },
-        "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
-            {
-                "href": "http:\/\/default\/sites\/default\/files\/donald-giannatti-671274-unsplash.jpg",
-                "lang": "en"
-            }
-        ],
         "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
             {
                 "href": "http:\/\/default\/user\/1?_format=hal_json",
+                "lang": "en"
+            }
+        ],
+        "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
+            {
+                "href": "http:\/\/default\/sites\/default\/files\/donald-giannatti-671274-unsplash.jpg",
                 "lang": "en"
             }
         ],
@@ -53,7 +53,7 @@
     ],
     "revision_created": [
         {
-            "value": "2019-04-10T13:59:54+00:00",
+            "value": "2019-05-08T14:50:16+00:00",
             "format": "Y-m-d\\TH:i:sP"
         }
     ],
@@ -63,13 +63,25 @@
             "lang": "en"
         }
     ],
-    "name": [
-        {
-            "value": "donald-giannatti-671274-unsplash.jpg",
-            "lang": "en"
-        }
-    ],
     "_embedded": {
+        "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "http:\/\/default\/user\/1?_format=hal_json"
+                    },
+                    "type": {
+                        "href": "http:\/\/drupal.org\/rest\/type\/user\/user"
+                    }
+                },
+                "uuid": [
+                    {
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
+                    }
+                ],
+                "lang": "en"
+            }
+        ],
         "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
             {
                 "_links": {
@@ -83,24 +95,6 @@
                 "uuid": [
                     {
                         "value": "5611795c-f843-4734-a3c7-6ddcdf75ef92"
-                    }
-                ],
-                "lang": "en"
-            }
-        ],
-        "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
-            {
-                "_links": {
-                    "self": {
-                        "href": "http:\/\/default\/user\/1?_format=hal_json"
-                    },
-                    "type": {
-                        "href": "http:\/\/drupal.org\/rest\/type\/user\/user"
-                    }
-                },
-                "uuid": [
-                    {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
                     }
                 ],
                 "lang": "en"
@@ -125,6 +119,12 @@
             }
         ]
     },
+    "name": [
+        {
+            "value": "donald-giannatti-671274-unsplash.jpg",
+            "lang": "en"
+        }
+    ],
     "created": [
         {
             "value": "2019-03-15T18:45:46+00:00",

--- a/modules/custom/apigee_kickstart_content/content/media/f3c8694f-bda0-4dec-ae89-0db3e59e8e7a.json
+++ b/modules/custom/apigee_kickstart_content/content/media/f3c8694f-bda0-4dec-ae89-0db3e59e8e7a.json
@@ -1,20 +1,20 @@
 {
     "_links": {
         "self": {
-            "href": "http:\/\/default\/media\/7?_format=hal_json"
+            "href": "http:\/\/default\/media\/7\/edit?_format=hal_json"
         },
         "type": {
             "href": "http:\/\/drupal.org\/rest\/type\/media\/image"
         },
-        "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
-            {
-                "href": "http:\/\/default\/sites\/default\/files\/nasa-43569-unsplash.jpg",
-                "lang": "en"
-            }
-        ],
         "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
             {
                 "href": "http:\/\/default\/user\/1?_format=hal_json",
+                "lang": "en"
+            }
+        ],
+        "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
+            {
+                "href": "http:\/\/default\/sites\/default\/files\/nasa-43569-unsplash.jpg",
                 "lang": "en"
             }
         ],
@@ -53,7 +53,7 @@
     ],
     "revision_created": [
         {
-            "value": "2019-04-04T02:12:42+00:00",
+            "value": "2019-05-08T14:50:16+00:00",
             "format": "Y-m-d\\TH:i:sP"
         }
     ],
@@ -63,13 +63,25 @@
             "lang": "en"
         }
     ],
-    "name": [
-        {
-            "value": "nasa-43569-unsplash.jpg",
-            "lang": "en"
-        }
-    ],
     "_embedded": {
+        "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "http:\/\/default\/user\/1?_format=hal_json"
+                    },
+                    "type": {
+                        "href": "http:\/\/drupal.org\/rest\/type\/user\/user"
+                    }
+                },
+                "uuid": [
+                    {
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
+                    }
+                ],
+                "lang": "en"
+            }
+        ],
         "http:\/\/drupal.org\/rest\/relation\/media\/image\/thumbnail": [
             {
                 "_links": {
@@ -83,24 +95,6 @@
                 "uuid": [
                     {
                         "value": "75a9d1ad-6294-42a9-9516-dc5c6623bb9e"
-                    }
-                ],
-                "lang": "en"
-            }
-        ],
-        "http:\/\/drupal.org\/rest\/relation\/media\/image\/uid": [
-            {
-                "_links": {
-                    "self": {
-                        "href": "http:\/\/default\/user\/1?_format=hal_json"
-                    },
-                    "type": {
-                        "href": "http:\/\/drupal.org\/rest\/type\/user\/user"
-                    }
-                },
-                "uuid": [
-                    {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
                     }
                 ],
                 "lang": "en"
@@ -125,6 +119,12 @@
             }
         ]
     },
+    "name": [
+        {
+            "value": "nasa-43569-unsplash.jpg",
+            "lang": "en"
+        }
+    ],
     "created": [
         {
             "value": "2019-03-17T03:48:35+00:00",

--- a/modules/custom/apigee_kickstart_content/content/menu_link_content/00d028d8-36f3-4758-b644-d4d55f7f0cce.json
+++ b/modules/custom/apigee_kickstart_content/content/menu_link_content/00d028d8-36f3-4758-b644-d4d55f7f0cce.json
@@ -17,6 +17,11 @@
             "value": "00d028d8-36f3-4758-b644-d4d55f7f0cce"
         }
     ],
+    "revision_id": [
+        {
+            "value": 1
+        }
+    ],
     "langcode": [
         {
             "value": "en",
@@ -26,6 +31,12 @@
     "bundle": [
         {
             "value": "menu_link_content"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2019-05-08T14:50:16+00:00",
+            "format": "Y-m-d\\TH:i:sP"
         }
     ],
     "enabled": [
@@ -79,6 +90,12 @@
         }
     ],
     "default_langcode": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "revision_translation_affected": [
         {
             "value": true,
             "lang": "en"

--- a/modules/custom/apigee_kickstart_content/content/menu_link_content/0dc221ed-fabe-464a-9a09-18e7398952df.json
+++ b/modules/custom/apigee_kickstart_content/content/menu_link_content/0dc221ed-fabe-464a-9a09-18e7398952df.json
@@ -17,6 +17,11 @@
             "value": "0dc221ed-fabe-464a-9a09-18e7398952df"
         }
     ],
+    "revision_id": [
+        {
+            "value": 2
+        }
+    ],
     "langcode": [
         {
             "value": "en",
@@ -26,6 +31,12 @@
     "bundle": [
         {
             "value": "menu_link_content"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2019-05-08T14:50:16+00:00",
+            "format": "Y-m-d\\TH:i:sP"
         }
     ],
     "enabled": [
@@ -79,6 +90,12 @@
         }
     ],
     "default_langcode": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "revision_translation_affected": [
         {
             "value": true,
             "lang": "en"

--- a/modules/custom/apigee_kickstart_content/content/menu_link_content/17a960ae-8e88-4f7f-b000-56076f076e95.json
+++ b/modules/custom/apigee_kickstart_content/content/menu_link_content/17a960ae-8e88-4f7f-b000-56076f076e95.json
@@ -17,6 +17,11 @@
             "value": "17a960ae-8e88-4f7f-b000-56076f076e95"
         }
     ],
+    "revision_id": [
+        {
+            "value": 3
+        }
+    ],
     "langcode": [
         {
             "value": "en",
@@ -26,6 +31,12 @@
     "bundle": [
         {
             "value": "menu_link_content"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2019-05-08T14:50:16+00:00",
+            "format": "Y-m-d\\TH:i:sP"
         }
     ],
     "enabled": [
@@ -79,6 +90,12 @@
         }
     ],
     "default_langcode": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "revision_translation_affected": [
         {
             "value": true,
             "lang": "en"

--- a/modules/custom/apigee_kickstart_content/content/node/08dd5a22-1712-41b2-8afb-3623b83d9a74.json
+++ b/modules/custom/apigee_kickstart_content/content/node/08dd5a22-1712-41b2-8afb-3623b83d9a74.json
@@ -69,7 +69,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }
@@ -86,7 +86,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ],
                 "lang": "en"
@@ -164,7 +164,7 @@
     "path": [
         {
             "alias": "\/forum\/security-tokens-documentation",
-            "pid": 11,
+            "pid": 13,
             "langcode": "en",
             "lang": "en"
         }
@@ -175,6 +175,17 @@
             "format": "basic_html",
             "processed": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis dictum nibh justo, a facilisis libero sodales vel. Vivamus ut nisi non nunc malesuada sagittis non condimentum tellus. Ut pharetra quis augue sed placerat. In ut mollis turpis. Aliquam sed luctus nibh, sed mattis urna. Integer mattis mi in massa hendrerit commodo. Sed et consequat nibh. Nam efficitur nunc non mi lacinia eleifend. Phasellus tempus ipsum vel elit iaculis lacinia.<\/p>\n\n<p>Ut ac efficitur orci. Phasellus commodo orci neque, a lobortis purus malesuada in. Nullam id eros vel enim suscipit tristique vestibulum sit amet orci. Duis sed iaculis elit, et tincidunt turpis. Sed venenatis mauris vitae molestie lobortis. Mauris aliquam, lacus dictum blandit tincidunt, elit mauris vestibulum risus, eu consequat nisi arcu sit amet dui. Vivamus malesuada volutpat sapien, id feugiat dolor finibus nec. Suspendisse vulputate erat eu elit ultricies, vel congue dui tempor. Sed hendrerit gravida eros a imperdiet. Donec eget euismod metus. Curabitur enim dui, posuere non euismod mattis, varius id justo.<\/p>",
             "summary": "",
+            "lang": "en"
+        }
+    ],
+    "comment_forum": [
+        {
+            "status": 2,
+            "cid": 2,
+            "last_comment_timestamp": 1554318655,
+            "last_comment_name": "",
+            "last_comment_uid": 1,
+            "comment_count": 1,
             "lang": "en"
         }
     ]

--- a/modules/custom/apigee_kickstart_content/content/node/092445b5-0f8e-4dc5-a56a-7fa4c5de8136.json
+++ b/modules/custom/apigee_kickstart_content/content/node/092445b5-0f8e-4dc5-a56a-7fa4c5de8136.json
@@ -63,7 +63,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }
@@ -80,7 +80,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ],
                 "lang": "en"
@@ -140,7 +140,7 @@
     "path": [
         {
             "alias": "\/faq\/where-do-i-go-request-api-keys",
-            "pid": 6,
+            "pid": 5,
             "langcode": "en",
             "lang": "en"
         }

--- a/modules/custom/apigee_kickstart_content/content/node/1924bd12-dac3-4377-b4e8-daec91f30c1b.json
+++ b/modules/custom/apigee_kickstart_content/content/node/1924bd12-dac3-4377-b4e8-daec91f30c1b.json
@@ -63,7 +63,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }
@@ -80,7 +80,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ],
                 "lang": "en"
@@ -139,7 +139,7 @@
     "path": [
         {
             "alias": "\/terms-and-conditions",
-            "pid": 1,
+            "pid": 6,
             "langcode": "en",
             "lang": "en"
         }

--- a/modules/custom/apigee_kickstart_content/content/node/35dc3dd9-205d-4fea-954f-39297c71b50f.json
+++ b/modules/custom/apigee_kickstart_content/content/node/35dc3dd9-205d-4fea-954f-39297c71b50f.json
@@ -74,7 +74,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }
@@ -91,7 +91,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ],
                 "lang": "en"

--- a/modules/custom/apigee_kickstart_content/content/node/3890114e-688b-4c8e-9a87-e74a22b0e456.json
+++ b/modules/custom/apigee_kickstart_content/content/node/3890114e-688b-4c8e-9a87-e74a22b0e456.json
@@ -19,7 +19,7 @@
         ],
         "http:\/\/drupal.org\/rest\/relation\/node\/article\/field_image": [
             {
-                "href": "http:\/\/default\/media\/5?_format=hal_json"
+                "href": "http:\/\/default\/media\/5\/edit?_format=hal_json"
             }
         ],
         "http:\/\/drupal.org\/rest\/relation\/node\/article\/field_tags": [
@@ -74,7 +74,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }
@@ -91,7 +91,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ],
                 "lang": "en"
@@ -101,7 +101,7 @@
             {
                 "_links": {
                     "self": {
-                        "href": "http:\/\/default\/media\/5?_format=hal_json"
+                        "href": "http:\/\/default\/media\/5\/edit?_format=hal_json"
                     },
                     "type": {
                         "href": "http:\/\/drupal.org\/rest\/type\/media\/image"
@@ -197,6 +197,17 @@
             "format": "basic_html",
             "processed": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam pulvinar erat eget malesuada ultrices. Praesent nec porta tellus. Curabitur sollicitudin elementum maximus. Ut vel massa vitae turpis rhoncus congue. Donec aliquam justo a fermentum fermentum. Cras augue turpis, tempor quis sapien ut, eleifend suscipit nibh. Sed sapien felis, bibendum sed est sit amet, ullamcorper rhoncus nulla. Quisque eget accumsan diam. Cras vel consequat arcu. Quisque nec diam placerat, molestie urna finibus, aliquam ipsum. Phasellus vitae pulvinar urna. Fusce eu velit imperdiet massa finibus gravida vel at tellus. Suspendisse ipsum urna, pulvinar eu nunc blandit, consectetur iaculis turpis. Quisque ac volutpat odio, quis efficitur lectus. Curabitur vel sagittis ligula.<\/p>\n\n<p>Nam hendrerit orci id neque vehicula, vitae vulputate enim sagittis. Suspendisse potenti. Pellentesque vestibulum sollicitudin nulla ac convallis. Phasellus eu ante tempus quam consequat placerat. Phasellus quis ligula ut augue maximus lobortis id et felis. Phasellus eu dapibus dui. Suspendisse molestie finibus cursus. Suspendisse potenti. Vivamus sollicitudin cursus tristique. Vestibulum eget leo a magna efficitur mattis. Mauris convallis ut quam ac fermentum. Nunc pulvinar venenatis nisi, sit amet varius neque suscipit id. Fusce ullamcorper, mi sed eleifend eleifend, velit mauris ullamcorper ipsum, a commodo felis libero ut elit.<\/p>",
             "summary": "Tellus cras adipiscing enim eu turpis egestas pretium aenean. Est ultricies integer quis auctor. Tortor aliquam nulla facilisi cras fermentum odio eu.",
+            "lang": "en"
+        }
+    ],
+    "comment": [
+        {
+            "status": 2,
+            "cid": 0,
+            "last_comment_timestamp": 1552792578,
+            "last_comment_name": null,
+            "last_comment_uid": 1,
+            "comment_count": 0,
             "lang": "en"
         }
     ]

--- a/modules/custom/apigee_kickstart_content/content/node/65a93625-1bbb-4e24-b3bd-87c432ecec21.json
+++ b/modules/custom/apigee_kickstart_content/content/node/65a93625-1bbb-4e24-b3bd-87c432ecec21.json
@@ -63,7 +63,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }
@@ -80,7 +80,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ],
                 "lang": "en"
@@ -140,7 +140,7 @@
     "path": [
         {
             "alias": "\/faq\/im-not-getting-expected-response-who-do-i-contact",
-            "pid": 7,
+            "pid": 4,
             "langcode": "en",
             "lang": "en"
         }

--- a/modules/custom/apigee_kickstart_content/content/node/7c30dc66-b866-4b9d-8351-0de09bee8094.json
+++ b/modules/custom/apigee_kickstart_content/content/node/7c30dc66-b866-4b9d-8351-0de09bee8094.json
@@ -19,7 +19,7 @@
         ],
         "http:\/\/drupal.org\/rest\/relation\/node\/article\/field_image": [
             {
-                "href": "http:\/\/default\/media\/4?_format=hal_json"
+                "href": "http:\/\/default\/media\/4\/edit?_format=hal_json"
             }
         ],
         "http:\/\/drupal.org\/rest\/relation\/node\/article\/field_tags": [
@@ -74,7 +74,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }
@@ -91,7 +91,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ],
                 "lang": "en"
@@ -101,7 +101,7 @@
             {
                 "_links": {
                     "self": {
-                        "href": "http:\/\/default\/media\/4?_format=hal_json"
+                        "href": "http:\/\/default\/media\/4\/edit?_format=hal_json"
                     },
                     "type": {
                         "href": "http:\/\/drupal.org\/rest\/type\/media\/image"
@@ -197,6 +197,17 @@
             "format": "basic_html",
             "processed": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis dictum nibh justo, a facilisis libero sodales vel. Vivamus ut nisi non nunc malesuada sagittis non condimentum tellus. Ut pharetra quis augue sed placerat. In ut mollis turpis. Aliquam sed luctus nibh, sed mattis urna. Integer mattis mi in massa hendrerit commodo. Sed et consequat nibh. Nam efficitur nunc non mi lacinia eleifend. Phasellus tempus ipsum vel elit iaculis lacinia.<\/p>\n\n<p>Ut ac efficitur orci. Phasellus commodo orci neque, a lobortis purus malesuada in. Nullam id eros vel enim suscipit tristique vestibulum sit amet orci. Duis sed iaculis elit, et tincidunt turpis. Sed venenatis mauris vitae molestie lobortis. Mauris aliquam, lacus dictum blandit tincidunt, elit mauris vestibulum risus, eu consequat nisi arcu sit amet dui. Vivamus malesuada volutpat sapien, id feugiat dolor finibus nec. Suspendisse vulputate erat eu elit ultricies, vel congue dui tempor. Sed hendrerit gravida eros a imperdiet. Donec eget euismod metus. Curabitur enim dui, posuere non euismod mattis, varius id justo.<\/p>",
             "summary": "Tellus cras adipiscing enim eu turpis egestas pretium aenean. Est ultricies integer quis auctor. Tortor aliquam nulla facilisi cras fermentum odio eu.",
+            "lang": "en"
+        }
+    ],
+    "comment": [
+        {
+            "status": 2,
+            "cid": 0,
+            "last_comment_timestamp": 1552793327,
+            "last_comment_name": null,
+            "last_comment_uid": 1,
+            "comment_count": 0,
             "lang": "en"
         }
     ]

--- a/modules/custom/apigee_kickstart_content/content/node/7fde3835-2c65-4df2-abd4-227eab08098a.json
+++ b/modules/custom/apigee_kickstart_content/content/node/7fde3835-2c65-4df2-abd4-227eab08098a.json
@@ -19,7 +19,7 @@
         ],
         "http:\/\/drupal.org\/rest\/relation\/node\/article\/field_image": [
             {
-                "href": "http:\/\/default\/media\/6?_format=hal_json"
+                "href": "http:\/\/default\/media\/6\/edit?_format=hal_json"
             }
         ],
         "http:\/\/drupal.org\/rest\/relation\/node\/article\/field_tags": [
@@ -74,7 +74,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }
@@ -91,7 +91,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ],
                 "lang": "en"
@@ -101,7 +101,7 @@
             {
                 "_links": {
                     "self": {
-                        "href": "http:\/\/default\/media\/6?_format=hal_json"
+                        "href": "http:\/\/default\/media\/6\/edit?_format=hal_json"
                     },
                     "type": {
                         "href": "http:\/\/drupal.org\/rest\/type\/media\/image"
@@ -197,6 +197,17 @@
             "format": "basic_html",
             "processed": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis dictum nibh justo, a facilisis libero sodales vel. Vivamus ut nisi non nunc malesuada sagittis non condimentum tellus. Ut pharetra quis augue sed placerat. In ut mollis turpis. Aliquam sed luctus nibh, sed mattis urna. Integer mattis mi in massa hendrerit commodo. Sed et consequat nibh. Nam efficitur nunc non mi lacinia eleifend. Phasellus tempus ipsum vel elit iaculis lacinia.<\/p>\n\n<p>Ut ac efficitur orci. Phasellus commodo orci neque, a lobortis purus malesuada in. Nullam id eros vel enim suscipit tristique vestibulum sit amet orci. Duis sed iaculis elit, et tincidunt turpis. Sed venenatis mauris vitae molestie lobortis. Mauris aliquam, lacus dictum blandit tincidunt, elit mauris vestibulum risus, eu consequat nisi arcu sit amet dui. Vivamus malesuada volutpat sapien, id feugiat dolor finibus nec. Suspendisse vulputate erat eu elit ultricies, vel congue dui tempor. Sed hendrerit gravida eros a imperdiet. Donec eget euismod metus. Curabitur enim dui, posuere non euismod mattis, varius id justo.<\/p>",
             "summary": "",
+            "lang": "en"
+        }
+    ],
+    "comment": [
+        {
+            "status": 2,
+            "cid": 0,
+            "last_comment_timestamp": 1552793240,
+            "last_comment_name": null,
+            "last_comment_uid": 1,
+            "comment_count": 0,
             "lang": "en"
         }
     ]

--- a/modules/custom/apigee_kickstart_content/content/node/81a691d1-0f93-4374-bb28-c42fc6cc1692.json
+++ b/modules/custom/apigee_kickstart_content/content/node/81a691d1-0f93-4374-bb28-c42fc6cc1692.json
@@ -63,7 +63,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }
@@ -80,7 +80,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ],
                 "lang": "en"

--- a/modules/custom/apigee_kickstart_content/content/node/88696329-c494-40c5-9339-dfaab375f092.json
+++ b/modules/custom/apigee_kickstart_content/content/node/88696329-c494-40c5-9339-dfaab375f092.json
@@ -19,7 +19,7 @@
         ],
         "http:\/\/drupal.org\/rest\/relation\/node\/article\/field_image": [
             {
-                "href": "http:\/\/default\/media\/7?_format=hal_json"
+                "href": "http:\/\/default\/media\/7\/edit?_format=hal_json"
             }
         ],
         "http:\/\/drupal.org\/rest\/relation\/node\/article\/field_tags": [
@@ -74,7 +74,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }
@@ -91,7 +91,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ],
                 "lang": "en"
@@ -101,7 +101,7 @@
             {
                 "_links": {
                     "self": {
-                        "href": "http:\/\/default\/media\/7?_format=hal_json"
+                        "href": "http:\/\/default\/media\/7\/edit?_format=hal_json"
                     },
                     "type": {
                         "href": "http:\/\/drupal.org\/rest\/type\/media\/image"
@@ -197,6 +197,17 @@
             "format": "basic_html",
             "processed": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis dictum nibh justo, a facilisis libero sodales vel. Vivamus ut nisi non nunc malesuada sagittis non condimentum tellus. Ut pharetra quis augue sed placerat. In ut mollis turpis. Aliquam sed luctus nibh, sed mattis urna. Integer mattis mi in massa hendrerit commodo. Sed et consequat nibh. Nam efficitur nunc non mi lacinia eleifend. Phasellus tempus ipsum vel elit iaculis lacinia.<\/p>\n\n<p>Ut ac efficitur orci. Phasellus commodo orci neque, a lobortis purus malesuada in. Nullam id eros vel enim suscipit tristique vestibulum sit amet orci. Duis sed iaculis elit, et tincidunt turpis. Sed venenatis mauris vitae molestie lobortis. Mauris aliquam, lacus dictum blandit tincidunt, elit mauris vestibulum risus, eu consequat nisi arcu sit amet dui. Vivamus malesuada volutpat sapien, id feugiat dolor finibus nec. Suspendisse vulputate erat eu elit ultricies, vel congue dui tempor. Sed hendrerit gravida eros a imperdiet. Donec eget euismod metus. Curabitur enim dui, posuere non euismod mattis, varius id justo.<\/p>",
             "summary": "Tellus cras adipiscing enim eu turpis egestas pretium aenean. Est ultricies integer quis auctor. Tortor aliquam nulla facilisi cras fermentum odio eu.",
+            "lang": "en"
+        }
+    ],
+    "comment": [
+        {
+            "status": 2,
+            "cid": 0,
+            "last_comment_timestamp": 1552794565,
+            "last_comment_name": null,
+            "last_comment_uid": 1,
+            "comment_count": 0,
             "lang": "en"
         }
     ]

--- a/modules/custom/apigee_kickstart_content/content/node/8d66ec13-400c-4c67-b1d2-19d481b7c04e.json
+++ b/modules/custom/apigee_kickstart_content/content/node/8d66ec13-400c-4c67-b1d2-19d481b7c04e.json
@@ -19,7 +19,7 @@
         ],
         "http:\/\/drupal.org\/rest\/relation\/node\/article\/field_image": [
             {
-                "href": "http:\/\/default\/media\/2?_format=hal_json"
+                "href": "http:\/\/default\/media\/2\/edit?_format=hal_json"
             }
         ],
         "http:\/\/drupal.org\/rest\/relation\/node\/article\/field_tags": [
@@ -74,7 +74,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }
@@ -91,7 +91,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ],
                 "lang": "en"
@@ -101,7 +101,7 @@
             {
                 "_links": {
                     "self": {
-                        "href": "http:\/\/default\/media\/2?_format=hal_json"
+                        "href": "http:\/\/default\/media\/2\/edit?_format=hal_json"
                     },
                     "type": {
                         "href": "http:\/\/drupal.org\/rest\/type\/media\/image"
@@ -197,6 +197,17 @@
             "format": "basic_html",
             "processed": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis dictum nibh justo, a facilisis libero sodales vel. Vivamus ut nisi non nunc malesuada sagittis non condimentum tellus. Ut pharetra quis augue sed placerat. In ut mollis turpis. Aliquam sed luctus nibh, sed mattis urna. Integer mattis mi in massa hendrerit commodo. Sed et consequat nibh. Nam efficitur nunc non mi lacinia eleifend. Phasellus tempus ipsum vel elit iaculis lacinia.<\/p>\n\n<p>Ut ac efficitur orci. Phasellus commodo orci neque, a lobortis purus malesuada in. Nullam id eros vel enim suscipit tristique vestibulum sit amet orci. Duis sed iaculis elit, et tincidunt turpis. Sed venenatis mauris vitae molestie lobortis. Mauris aliquam, lacus dictum blandit tincidunt, elit mauris vestibulum risus, eu consequat nisi arcu sit amet dui. Vivamus malesuada volutpat sapien, id feugiat dolor finibus nec. Suspendisse vulputate erat eu elit ultricies, vel congue dui tempor. Sed hendrerit gravida eros a imperdiet. Donec eget euismod metus. Curabitur enim dui, posuere non euismod mattis, varius id justo.<\/p>",
             "summary": "Tellus cras adipiscing enim eu turpis egestas pretium aenean. Est ultricies integer quis auctor. Tortor aliquam nulla facilisi cras fermentum odio eu.",
+            "lang": "en"
+        }
+    ],
+    "comment": [
+        {
+            "status": 2,
+            "cid": 0,
+            "last_comment_timestamp": 1552792569,
+            "last_comment_name": null,
+            "last_comment_uid": 1,
+            "comment_count": 0,
             "lang": "en"
         }
     ]

--- a/modules/custom/apigee_kickstart_content/content/node/abc89fd3-4cda-46bb-aa3d-416f5639ef3c.json
+++ b/modules/custom/apigee_kickstart_content/content/node/abc89fd3-4cda-46bb-aa3d-416f5639ef3c.json
@@ -19,7 +19,7 @@
         ],
         "http:\/\/drupal.org\/rest\/relation\/node\/article\/field_image": [
             {
-                "href": "http:\/\/default\/media\/8?_format=hal_json"
+                "href": "http:\/\/default\/media\/8\/edit?_format=hal_json"
             }
         ],
         "http:\/\/drupal.org\/rest\/relation\/node\/article\/field_tags": [
@@ -74,7 +74,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }
@@ -91,7 +91,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ],
                 "lang": "en"
@@ -101,7 +101,7 @@
             {
                 "_links": {
                     "self": {
-                        "href": "http:\/\/default\/media\/8?_format=hal_json"
+                        "href": "http:\/\/default\/media\/8\/edit?_format=hal_json"
                     },
                     "type": {
                         "href": "http:\/\/drupal.org\/rest\/type\/media\/image"
@@ -197,6 +197,17 @@
             "format": "basic_html",
             "processed": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis dictum nibh justo, a facilisis libero sodales vel. Vivamus ut nisi non nunc malesuada sagittis non condimentum tellus. Ut pharetra quis augue sed placerat. In ut mollis turpis. Aliquam sed luctus nibh, sed mattis urna. Integer mattis mi in massa hendrerit commodo. Sed et consequat nibh. Nam efficitur nunc non mi lacinia eleifend. Phasellus tempus ipsum vel elit iaculis lacinia.<\/p>\n\n<p>Ut ac efficitur orci. Phasellus commodo orci neque, a lobortis purus malesuada in. Nullam id eros vel enim suscipit tristique vestibulum sit amet orci. Duis sed iaculis elit, et tincidunt turpis. Sed venenatis mauris vitae molestie lobortis. Mauris aliquam, lacus dictum blandit tincidunt, elit mauris vestibulum risus, eu consequat nisi arcu sit amet dui. Vivamus malesuada volutpat sapien, id feugiat dolor finibus nec. Suspendisse vulputate erat eu elit ultricies, vel congue dui tempor. Sed hendrerit gravida eros a imperdiet. Donec eget euismod metus. Curabitur enim dui, posuere non euismod mattis, varius id justo.<\/p>\n\n<p>Praesent porttitor mattis justo ac interdum. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nulla rutrum, sapien in faucibus cursus, lorem mauris tempus mi, nec cursus elit nunc eu purus. Quisque vulputate dolor in diam convallis, in rhoncus erat fermentum. Suspendisse a eros justo. Duis magna mi, semper sed nisl vitae, venenatis pellentesque lacus. Aenean blandit quam sed ligula cursus fringilla. Quisque id diam pharetra, rhoncus odio non, hendrerit sem. Nunc condimentum diam et suscipit lacinia. Sed vitae tellus vel quam finibus pharetra. Aenean rutrum velit urna, id dignissim sem pellentesque molestie. Quisque et vulputate augue, nec viverra sapien. Nunc aliquam orci eu dolor gravida pretium. Aliquam a rhoncus urna. Nam leo turpis, vehicula sit amet vehicula nec, fermentum non ipsum.<\/p>",
             "summary": "Tellus cras adipiscing enim eu turpis egestas pretium aenean. Est ultricies integer quis auctor. Tortor aliquam nulla facilisi cras fermentum odio eu.",
+            "lang": "en"
+        }
+    ],
+    "comment": [
+        {
+            "status": 2,
+            "cid": 1,
+            "last_comment_timestamp": 1554122417,
+            "last_comment_name": "",
+            "last_comment_uid": 1,
+            "comment_count": 1,
             "lang": "en"
         }
     ]

--- a/modules/custom/apigee_kickstart_content/content/node/acf16bcc-b4f1-4dc4-8240-ceb98007d2ee.json
+++ b/modules/custom/apigee_kickstart_content/content/node/acf16bcc-b4f1-4dc4-8240-ceb98007d2ee.json
@@ -86,7 +86,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }
@@ -103,7 +103,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ],
                 "lang": "en"

--- a/modules/custom/apigee_kickstart_content/content/node/c92c7326-0042-43f0-b37c-e3409141fb8a.json
+++ b/modules/custom/apigee_kickstart_content/content/node/c92c7326-0042-43f0-b37c-e3409141fb8a.json
@@ -69,7 +69,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }
@@ -86,7 +86,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ],
                 "lang": "en"
@@ -164,7 +164,7 @@
     "path": [
         {
             "alias": "\/forum\/getting-started-real-time-apis",
-            "pid": 13,
+            "pid": 12,
             "langcode": "en",
             "lang": "en"
         }
@@ -175,6 +175,17 @@
             "format": "basic_html",
             "processed": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis dictum nibh justo, a facilisis libero sodales vel. Vivamus ut nisi non nunc malesuada sagittis non condimentum tellus. Ut pharetra quis augue sed placerat. In ut mollis turpis. Aliquam sed luctus nibh, sed mattis urna. Integer mattis mi in massa hendrerit commodo. Sed et consequat nibh. Nam efficitur nunc non mi lacinia eleifend. Phasellus tempus ipsum vel elit iaculis lacinia.<\/p>\n\n<p>Ut ac efficitur orci. Phasellus commodo orci neque, a lobortis purus malesuada in. Nullam id eros vel enim suscipit tristique vestibulum sit amet orci. Duis sed iaculis elit, et tincidunt turpis. Sed venenatis mauris vitae molestie lobortis. Mauris aliquam, lacus dictum blandit tincidunt, elit mauris vestibulum risus, eu consequat nisi arcu sit amet dui. Vivamus malesuada volutpat sapien, id feugiat dolor finibus nec. Suspendisse vulputate erat eu elit ultricies, vel congue dui tempor. Sed hendrerit gravida eros a imperdiet. Donec eget euismod metus. Curabitur enim dui, posuere non euismod mattis, varius id justo.<\/p>",
             "summary": "",
+            "lang": "en"
+        }
+    ],
+    "comment_forum": [
+        {
+            "status": 2,
+            "cid": 0,
+            "last_comment_timestamp": 1553029424,
+            "last_comment_name": null,
+            "last_comment_uid": 1,
+            "comment_count": 0,
             "lang": "en"
         }
     ]

--- a/modules/custom/apigee_kickstart_content/content/node/e8a69fee-63d5-42fa-9daa-9fd027133276.json
+++ b/modules/custom/apigee_kickstart_content/content/node/e8a69fee-63d5-42fa-9daa-9fd027133276.json
@@ -69,7 +69,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }
@@ -86,7 +86,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ],
                 "lang": "en"
@@ -175,6 +175,17 @@
             "format": "basic_html",
             "processed": "<p>In a gravida nisi, in interdum urna. Nunc nec eros sed magna tincidunt vestibulum. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Duis facilisis tortor augue, eget facilisis arcu hendrerit at.<\/p>\n\n<p>Aliquam ultricies erat augue, sodales finibus dui rutrum et. Maecenas eget ipsum eu ante dictum auctor.<\/p>\n\n<p>Suspendisse sed orci nulla. Nullam id rhoncus lacus. Fusce velit enim, viverra ut tortor ultricies, tincidunt aliquet felis. Praesent porta eros et lacus blandit rutrum. Nulla sollicitudin ex elit, sit amet lobortis magna malesuada eget.<\/p>\n\n<p>Donec et dolor sed mi ornare imperdiet sit amet et justo. Duis blandit malesuada leo a pellentesque. Maecenas suscipit gravida leo, at convallis quam ullamcorper eu. Donec sollicitudin augue vitae luctus consequat. In tristique varius dapibus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae;<\/p>\n\n<p>Quisque eget erat risus. Phasellus iaculis orci id erat porttitor, quis tristique turpis cursus. Nulla gravida fermentum erat. Interdum et malesuada fames ac ante ipsum primis in faucibus. Nunc eu mollis velit.<\/p>",
             "summary": "",
+            "lang": "en"
+        }
+    ],
+    "comment_forum": [
+        {
+            "status": 2,
+            "cid": 0,
+            "last_comment_timestamp": 1553029414,
+            "last_comment_name": null,
+            "last_comment_uid": 1,
+            "comment_count": 0,
             "lang": "en"
         }
     ]

--- a/modules/custom/apigee_kickstart_content/content/node/ff6b399b-96d5-4366-8341-def6a7d25876.json
+++ b/modules/custom/apigee_kickstart_content/content/node/ff6b399b-96d5-4366-8341-def6a7d25876.json
@@ -63,7 +63,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ]
             }
@@ -80,7 +80,7 @@
                 },
                 "uuid": [
                     {
-                        "value": "24482b6d-ec75-4b49-b5e6-353844c52b13"
+                        "value": "6eb64048-db73-41c5-b8bb-ac8e908dae13"
                     }
                 ],
                 "lang": "en"
@@ -140,7 +140,7 @@
     "path": [
         {
             "alias": "\/faq\/what-difference-between-sandbox-url-and-live-url",
-            "pid": 3,
+            "pid": 8,
             "langcode": "en",
             "lang": "en"
         }

--- a/modules/custom/apigee_kickstart_content/content/paragraph/133a8cb0-6813-4a2c-9f8a-a4c7a9109268.json
+++ b/modules/custom/apigee_kickstart_content/content/paragraph/133a8cb0-6813-4a2c-9f8a-a4c7a9109268.json
@@ -8,7 +8,7 @@
         },
         "http:\/\/drupal.org\/rest\/relation\/paragraph\/card\/field_image": [
             {
-                "href": "http:\/\/default\/media\/4?_format=hal_json",
+                "href": "http:\/\/default\/media\/4\/edit?_format=hal_json",
                 "lang": "en"
             }
         ]
@@ -89,7 +89,7 @@
             {
                 "_links": {
                     "self": {
-                        "href": "http:\/\/default\/media\/4?_format=hal_json"
+                        "href": "http:\/\/default\/media\/4\/edit?_format=hal_json"
                     },
                     "type": {
                         "href": "http:\/\/drupal.org\/rest\/type\/media\/image"

--- a/modules/custom/apigee_kickstart_content/content/paragraph/338d65b4-8589-47bf-869e-63699ecdefea.json
+++ b/modules/custom/apigee_kickstart_content/content/paragraph/338d65b4-8589-47bf-869e-63699ecdefea.json
@@ -8,7 +8,7 @@
         },
         "http:\/\/drupal.org\/rest\/relation\/paragraph\/card\/field_image": [
             {
-                "href": "http:\/\/default\/media\/3?_format=hal_json",
+                "href": "http:\/\/default\/media\/3\/edit?_format=hal_json",
                 "lang": "en"
             }
         ]
@@ -89,7 +89,7 @@
             {
                 "_links": {
                     "self": {
-                        "href": "http:\/\/default\/media\/3?_format=hal_json"
+                        "href": "http:\/\/default\/media\/3\/edit?_format=hal_json"
                     },
                     "type": {
                         "href": "http:\/\/drupal.org\/rest\/type\/media\/image"

--- a/modules/custom/apigee_kickstart_content/content/paragraph/553bc28b-b818-4e1f-971d-647bb659c880.json
+++ b/modules/custom/apigee_kickstart_content/content/paragraph/553bc28b-b818-4e1f-971d-647bb659c880.json
@@ -8,7 +8,7 @@
         },
         "http:\/\/drupal.org\/rest\/relation\/paragraph\/card\/field_image": [
             {
-                "href": "http:\/\/default\/media\/2?_format=hal_json",
+                "href": "http:\/\/default\/media\/2\/edit?_format=hal_json",
                 "lang": "en"
             }
         ]
@@ -89,7 +89,7 @@
             {
                 "_links": {
                     "self": {
-                        "href": "http:\/\/default\/media\/2?_format=hal_json"
+                        "href": "http:\/\/default\/media\/2\/edit?_format=hal_json"
                     },
                     "type": {
                         "href": "http:\/\/drupal.org\/rest\/type\/media\/image"

--- a/modules/custom/apigee_kickstart_content/content/paragraph/73ec3b20-3b9a-43d1-bbcd-65362abe0fda.json
+++ b/modules/custom/apigee_kickstart_content/content/paragraph/73ec3b20-3b9a-43d1-bbcd-65362abe0fda.json
@@ -8,7 +8,7 @@
         },
         "http:\/\/drupal.org\/rest\/relation\/paragraph\/text_image\/field_image": [
             {
-                "href": "http:\/\/default\/media\/5?_format=hal_json"
+                "href": "http:\/\/default\/media\/5\/edit?_format=hal_json"
             }
         ]
     },
@@ -94,7 +94,7 @@
             {
                 "_links": {
                     "self": {
-                        "href": "http:\/\/default\/media\/5?_format=hal_json"
+                        "href": "http:\/\/default\/media\/5\/edit?_format=hal_json"
                     },
                     "type": {
                         "href": "http:\/\/drupal.org\/rest\/type\/media\/image"

--- a/modules/custom/apigee_kickstart_content/content/paragraph/7e2cbb90-7928-41dd-9240-09afaa1a14cf.json
+++ b/modules/custom/apigee_kickstart_content/content/paragraph/7e2cbb90-7928-41dd-9240-09afaa1a14cf.json
@@ -13,7 +13,7 @@
         ],
         "http:\/\/drupal.org\/rest\/relation\/paragraph\/hero\/field_media": [
             {
-                "href": "http:\/\/default\/media\/9?_format=hal_json"
+                "href": "http:\/\/default\/media\/9\/edit?_format=hal_json"
             }
         ]
     },
@@ -111,7 +111,7 @@
             {
                 "_links": {
                     "self": {
-                        "href": "http:\/\/default\/media\/9?_format=hal_json"
+                        "href": "http:\/\/default\/media\/9\/edit?_format=hal_json"
                     },
                     "type": {
                         "href": "http:\/\/drupal.org\/rest\/type\/media\/image"

--- a/modules/custom/apigee_kickstart_content/content/taxonomy_term/14aca1e1-227d-4a96-b340-9910f4ff087c.json
+++ b/modules/custom/apigee_kickstart_content/content/taxonomy_term/14aca1e1-227d-4a96-b340-9910f4ff087c.json
@@ -20,6 +20,11 @@
             "value": "14aca1e1-227d-4a96-b340-9910f4ff087c"
         }
     ],
+    "revision_id": [
+        {
+            "value": 9
+        }
+    ],
     "langcode": [
         {
             "value": "en",
@@ -29,6 +34,12 @@
     "vid": [
         {
             "target_id": "api_category"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2019-05-08T14:50:16+00:00",
+            "format": "Y-m-d\\TH:i:sP"
         }
     ],
     "status": [
@@ -61,6 +72,12 @@
         }
     ],
     "default_langcode": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "revision_translation_affected": [
         {
             "value": true,
             "lang": "en"

--- a/modules/custom/apigee_kickstart_content/content/taxonomy_term/21610fde-d521-4f1b-b56f-63cdee1aec2a.json
+++ b/modules/custom/apigee_kickstart_content/content/taxonomy_term/21610fde-d521-4f1b-b56f-63cdee1aec2a.json
@@ -20,6 +20,11 @@
             "value": "21610fde-d521-4f1b-b56f-63cdee1aec2a"
         }
     ],
+    "revision_id": [
+        {
+            "value": 4
+        }
+    ],
     "langcode": [
         {
             "value": "en",
@@ -29,6 +34,12 @@
     "vid": [
         {
             "target_id": "forums"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2019-05-08T14:50:16+00:00",
+            "format": "Y-m-d\\TH:i:sP"
         }
     ],
     "status": [
@@ -74,10 +85,16 @@
             "lang": "en"
         }
     ],
+    "revision_translation_affected": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
     "path": [
         {
             "alias": "\/forum\/miscellaneous",
-            "pid": 2,
+            "pid": 3,
             "langcode": "en",
             "lang": "en"
         }

--- a/modules/custom/apigee_kickstart_content/content/taxonomy_term/40d3bba3-edec-4794-9481-3c4e21cdd396.json
+++ b/modules/custom/apigee_kickstart_content/content/taxonomy_term/40d3bba3-edec-4794-9481-3c4e21cdd396.json
@@ -20,6 +20,11 @@
             "value": "40d3bba3-edec-4794-9481-3c4e21cdd396"
         }
     ],
+    "revision_id": [
+        {
+            "value": 2
+        }
+    ],
     "langcode": [
         {
             "value": "en",
@@ -29,6 +34,12 @@
     "vid": [
         {
             "target_id": "forums"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2019-05-08T14:50:16+00:00",
+            "format": "Y-m-d\\TH:i:sP"
         }
     ],
     "status": [
@@ -74,10 +85,16 @@
             "lang": "en"
         }
     ],
+    "revision_translation_affected": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
     "path": [
         {
             "alias": "\/forum\/sales-apis",
-            "pid": 4,
+            "pid": 1,
             "langcode": "en",
             "lang": "en"
         }

--- a/modules/custom/apigee_kickstart_content/content/taxonomy_term/53652a5b-1721-414f-b30b-ee13a8ea06a6.json
+++ b/modules/custom/apigee_kickstart_content/content/taxonomy_term/53652a5b-1721-414f-b30b-ee13a8ea06a6.json
@@ -20,6 +20,11 @@
             "value": "53652a5b-1721-414f-b30b-ee13a8ea06a6"
         }
     ],
+    "revision_id": [
+        {
+            "value": 7
+        }
+    ],
     "langcode": [
         {
             "value": "en",
@@ -29,6 +34,12 @@
     "vid": [
         {
             "target_id": "api_category"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2019-05-08T14:50:16+00:00",
+            "format": "Y-m-d\\TH:i:sP"
         }
     ],
     "status": [
@@ -61,6 +72,12 @@
         }
     ],
     "default_langcode": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "revision_translation_affected": [
         {
             "value": true,
             "lang": "en"

--- a/modules/custom/apigee_kickstart_content/content/taxonomy_term/5869a2b7-3d46-4cfe-b2c7-59044b86c06a.json
+++ b/modules/custom/apigee_kickstart_content/content/taxonomy_term/5869a2b7-3d46-4cfe-b2c7-59044b86c06a.json
@@ -20,6 +20,11 @@
             "value": "5869a2b7-3d46-4cfe-b2c7-59044b86c06a"
         }
     ],
+    "revision_id": [
+        {
+            "value": 3
+        }
+    ],
     "langcode": [
         {
             "value": "en",
@@ -29,6 +34,12 @@
     "vid": [
         {
             "target_id": "forums"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2019-05-08T14:50:16+00:00",
+            "format": "Y-m-d\\TH:i:sP"
         }
     ],
     "status": [
@@ -74,10 +85,16 @@
             "lang": "en"
         }
     ],
+    "revision_translation_affected": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
     "path": [
         {
             "alias": "\/forum\/comments-suggestions",
-            "pid": 8,
+            "pid": 2,
             "langcode": "en",
             "lang": "en"
         }

--- a/modules/custom/apigee_kickstart_content/content/taxonomy_term/82a2a2ab-741c-4331-9ee5-211c8d4fd5cf.json
+++ b/modules/custom/apigee_kickstart_content/content/taxonomy_term/82a2a2ab-741c-4331-9ee5-211c8d4fd5cf.json
@@ -20,6 +20,11 @@
             "value": "82a2a2ab-741c-4331-9ee5-211c8d4fd5cf"
         }
     ],
+    "revision_id": [
+        {
+            "value": 5
+        }
+    ],
     "langcode": [
         {
             "value": "en",
@@ -29,6 +34,12 @@
     "vid": [
         {
             "target_id": "api_category"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2019-05-08T14:50:16+00:00",
+            "format": "Y-m-d\\TH:i:sP"
         }
     ],
     "status": [
@@ -66,10 +77,16 @@
             "lang": "en"
         }
     ],
+    "revision_translation_affected": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
     "path": [
         {
             "alias": "\/apis\/mobile",
-            "pid": 5,
+            "pid": 7,
             "langcode": "en",
             "lang": "en"
         }

--- a/modules/custom/apigee_kickstart_content/content/taxonomy_term/a09a32c1-fa1f-403b-888c-e02616998419.json
+++ b/modules/custom/apigee_kickstart_content/content/taxonomy_term/a09a32c1-fa1f-403b-888c-e02616998419.json
@@ -20,6 +20,11 @@
             "value": "a09a32c1-fa1f-403b-888c-e02616998419"
         }
     ],
+    "revision_id": [
+        {
+            "value": 6
+        }
+    ],
     "langcode": [
         {
             "value": "en",
@@ -29,6 +34,12 @@
     "vid": [
         {
             "target_id": "api_category"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2019-05-08T14:50:16+00:00",
+            "format": "Y-m-d\\TH:i:sP"
         }
     ],
     "status": [
@@ -66,10 +77,16 @@
             "lang": "en"
         }
     ],
+    "revision_translation_affected": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
     "path": [
         {
             "alias": "\/apis\/payment-transaction",
-            "pid": 12,
+            "pid": 11,
             "langcode": "en",
             "lang": "en"
         }

--- a/modules/custom/apigee_kickstart_content/content/taxonomy_term/a63cae7c-c969-487a-a6f5-6a66a045c447.json
+++ b/modules/custom/apigee_kickstart_content/content/taxonomy_term/a63cae7c-c969-487a-a6f5-6a66a045c447.json
@@ -20,6 +20,11 @@
             "value": "a63cae7c-c969-487a-a6f5-6a66a045c447"
         }
     ],
+    "revision_id": [
+        {
+            "value": 8
+        }
+    ],
     "langcode": [
         {
             "value": "en",
@@ -29,6 +34,12 @@
     "vid": [
         {
             "target_id": "api_category"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2019-05-08T14:50:16+00:00",
+            "format": "Y-m-d\\TH:i:sP"
         }
     ],
     "status": [
@@ -61,6 +72,12 @@
         }
     ],
     "default_langcode": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "revision_translation_affected": [
         {
             "value": true,
             "lang": "en"

--- a/modules/custom/apigee_kickstart_content/content/taxonomy_term/b96f6867-e1a8-4bdf-a8dd-ec61a47d100b.json
+++ b/modules/custom/apigee_kickstart_content/content/taxonomy_term/b96f6867-e1a8-4bdf-a8dd-ec61a47d100b.json
@@ -20,6 +20,11 @@
             "value": "b96f6867-e1a8-4bdf-a8dd-ec61a47d100b"
         }
     ],
+    "revision_id": [
+        {
+            "value": 11
+        }
+    ],
     "langcode": [
         {
             "value": "en",
@@ -29,6 +34,12 @@
     "vid": [
         {
             "target_id": "tags"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2019-05-08T14:50:16+00:00",
+            "format": "Y-m-d\\TH:i:sP"
         }
     ],
     "status": [
@@ -61,6 +72,12 @@
         }
     ],
     "default_langcode": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "revision_translation_affected": [
         {
             "value": true,
             "lang": "en"

--- a/modules/custom/apigee_kickstart_content/content/taxonomy_term/c5e62e4a-18c3-4d91-83aa-db55e16c48a6.json
+++ b/modules/custom/apigee_kickstart_content/content/taxonomy_term/c5e62e4a-18c3-4d91-83aa-db55e16c48a6.json
@@ -20,6 +20,11 @@
             "value": "c5e62e4a-18c3-4d91-83aa-db55e16c48a6"
         }
     ],
+    "revision_id": [
+        {
+            "value": 10
+        }
+    ],
     "langcode": [
         {
             "value": "en",
@@ -29,6 +34,12 @@
     "vid": [
         {
             "target_id": "tags"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2019-05-08T14:50:16+00:00",
+            "format": "Y-m-d\\TH:i:sP"
         }
     ],
     "status": [
@@ -61,6 +72,12 @@
         }
     ],
     "default_langcode": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "revision_translation_affected": [
         {
             "value": true,
             "lang": "en"


### PR DESCRIPTION
This also defines all content `info.yml` so that it may be exported via `drush dcem apigee_kickstart_content` which is an awesome feature and a massive time saver.

See updated documentation committed via: https://www.drupal.org/project/default_content/issues/2826455. 