### PR TITLE
 [DRUP-804] Implement Seven’s responsive tabs

### DIFF
--- a/themes/custom/apigee_kickstart/assets/css/apigee-kickstart.style.css
+++ b/themes/custom/apigee_kickstart/assets/css/apigee-kickstart.style.css
@@ -12312,6 +12312,12 @@ ul.social-links li a {
   color: #3c3c3c;
   border-bottom-color: var(--ak-accent-color);
 }
+.is-collapse-enabled .nav-tabs .nav-link.active {
+  border-right-color: var(--ak-accent-color);
+}
+.is-horizontal .nav-tabs .nav-link.active {
+  border-bottom-color: var(--ak-accent-color);
+}
 .nav-tabs .nav-link.active:after {
   content: "";
   height: 4px;
@@ -12320,6 +12326,7 @@ ul.social-links li a {
   left: 0;
   right: 0;
   bottom: 0;
+  z-index: 16;
 }
 
 .pagination {
@@ -12463,6 +12470,12 @@ ul.social-links li a {
   color: #3c3c3c;
   border-bottom-color: var(--ak-accent-color);
 }
+.is-collapse-enabled .nav-tabs .nav-link.active {
+  border-right-color: var(--ak-accent-color);
+}
+.is-horizontal .nav-tabs .nav-link.active {
+  border-bottom-color: var(--ak-accent-color);
+}
 .nav-tabs .nav-link.active:after {
   content: "";
   height: 4px;
@@ -12471,13 +12484,12 @@ ul.social-links li a {
   left: 0;
   right: 0;
   bottom: 0;
+  z-index: 16;
 }
 
 .nav-tabs--secondary {
   border-bottom: 1px solid #c8c8c8;
   font-size: 0.875rem;
-  flex-wrap: nowrap;
-  overflow: scroll;
 }
 .nav-tabs--secondary .nav-link {
   color: #a3a3a3;
@@ -12490,6 +12502,104 @@ ul.social-links li a {
 .nav-tabs--secondary .nav-link.active {
   color: #3c3c3c;
   border-bottom-color: var(--ak-accent-color);
+}
+
+.is-collapse-enabled .nav-tabs,
+.is-horizontal .nav-tabs {
+  clear: both;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  position: relative;
+}
+.is-collapse-enabled .nav-tabs:before,
+.is-horizontal .nav-tabs:before {
+  border-bottom: 1px solid #c8c8c8;
+  bottom: 0;
+  content: "";
+  display: block;
+  height: 1px;
+  left: 0;
+  position: absolute;
+  right: 0;
+  z-index: 10;
+}
+
+.is-collapse-enabled .nav-tabs {
+  max-height: 0;
+  overflow: hidden;
+  padding-top: 40px;
+}
+.is-collapse-enabled .nav-tabs:before {
+  right: 60px;
+}
+.is-collapse-enabled .nav-tabs.is-open::before {
+  display: none;
+}
+
+.nav-tabs.is-open {
+  max-height: 999em;
+}
+
+.is-horizontal .nav-tabs {
+  overflow: visible;
+  max-height: none !important;
+  padding-top: 0 !important;
+  border-bottom: 0;
+}
+
+.nav-tabs .nav-item {
+  display: block;
+  overflow: hidden;
+  position: relative;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.is-collapse-enabled .nav-item.active {
+  position: absolute;
+  top: 0;
+  left: 0;
+  /* LTR */
+  width: calc(100% - 60px);
+  z-index: 15;
+}
+
+.is-horizontal .nav-item {
+  float: left;
+  /* LTR */
+  width: auto;
+  height: auto;
+  text-align: center;
+}
+
+.is-horizontal .nav-item.active,
+.is-horizontal .nav-tabs.nav-tabs--primary .nav-item.active {
+  position: relative;
+  top: 0;
+  width: auto;
+}
+
+.tabs__trigger,
+.is-horizontal .tabs__trigger {
+  display: none;
+}
+
+/* JS dependent styling */
+.is-collapse-enabled .tabs__trigger {
+  background: var(--ak-accent-color);
+  border: 0;
+  color: var(--ak-accent-color-light);
+  display: block;
+  height: 40px;
+  left: auto;
+  outline: 0;
+  position: absolute;
+  right: 0;
+  text-align: center;
+  top: 0;
+  width: 60px;
+  z-index: 10;
 }
 
 .secret {

--- a/themes/custom/apigee_kickstart/assets/css/apigee-kickstart.style.css
+++ b/themes/custom/apigee_kickstart/assets/css/apigee-kickstart.style.css
@@ -1,7 +1,6 @@
 @charset "UTF-8";
 :root {
   --blue: #2196f3;
-  --blue-dark: #0c83e2;
   --indigo: #6610f2;
   --purple: #6f42c1;
   --pink: #e83e8c;
@@ -14,6 +13,7 @@
   --white: #fff;
   --gray: #787878;
   --gray-dark: #505050;
+  --blue-dark: #0c83e2;
   --primary: #2196f3;
   --secondary: #787878;
   --success: #53BE6D;
@@ -21,8 +21,8 @@
   --warning: #ffc107;
   --danger: #dc3545;
   --light: #f0f0f0;
-  --lighter: #f9f9f9;
   --dark: #505050;
+  --lighter: #f9f9f9;
   --breakpoint-xs: 0;
   --breakpoint-sm: 576px;
   --breakpoint-md: 768px;
@@ -1796,26 +1796,6 @@ pre code {
   background-color: #eeeeee;
 }
 
-.table-lighter,
-.table-lighter > th,
-.table-lighter > td {
-  background-color: #fdfdfd;
-}
-.table-lighter th,
-.table-lighter td,
-.table-lighter thead th,
-.table-lighter tbody + tbody {
-  border-color: #fcfcfc;
-}
-
-.table-hover .table-lighter:hover {
-  background-color: #f0f0f0;
-}
-.table-hover .table-lighter:hover > td,
-.table-hover .table-lighter:hover > th {
-  background-color: #f0f0f0;
-}
-
 .table-dark,
 .table-dark > th,
 .table-dark > td {
@@ -1834,6 +1814,26 @@ pre code {
 .table-hover .table-dark:hover > td,
 .table-hover .table-dark:hover > th {
   background-color: #c1c1c1;
+}
+
+.table-lighter,
+.table-lighter > th,
+.table-lighter > td {
+  background-color: #fdfdfd;
+}
+.table-lighter th,
+.table-lighter td,
+.table-lighter thead th,
+.table-lighter tbody + tbody {
+  border-color: #fcfcfc;
+}
+
+.table-hover .table-lighter:hover {
+  background-color: #f0f0f0;
+}
+.table-hover .table-lighter:hover > td,
+.table-hover .table-lighter:hover > th {
+  background-color: #f0f0f0;
 }
 
 .table-active,
@@ -2625,33 +2625,6 @@ fieldset:disabled a.btn {
   box-shadow: 0 0 0 0.2rem rgba(213, 213, 213, 0.5);
 }
 
-.btn-lighter {
-  color: #3c3c3c;
-  background-color: #f9f9f9;
-  border-color: #f9f9f9;
-}
-.btn-lighter:hover {
-  color: #3c3c3c;
-  background-color: #e6e6e6;
-  border-color: #e0e0e0;
-}
-.btn-lighter:focus, .btn-lighter.focus {
-  box-shadow: 0 0 0 0.2rem rgba(221, 221, 221, 0.5);
-}
-.btn-lighter.disabled, .btn-lighter:disabled {
-  color: #3c3c3c;
-  background-color: #f9f9f9;
-  border-color: #f9f9f9;
-}
-.btn-lighter:not(:disabled):not(.disabled):active, .btn-lighter:not(:disabled):not(.disabled).active, .show > .btn-lighter.dropdown-toggle {
-  color: #3c3c3c;
-  background-color: #e0e0e0;
-  border-color: #d9d9d9;
-}
-.btn-lighter:not(:disabled):not(.disabled):active:focus, .btn-lighter:not(:disabled):not(.disabled).active:focus, .show > .btn-lighter.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(221, 221, 221, 0.5);
-}
-
 .btn-dark {
   color: #fff;
   background-color: #505050;
@@ -2677,6 +2650,33 @@ fieldset:disabled a.btn {
 }
 .btn-dark:not(:disabled):not(.disabled):active:focus, .btn-dark:not(:disabled):not(.disabled).active:focus, .show > .btn-dark.dropdown-toggle:focus {
   box-shadow: 0 0 0 0.2rem rgba(106, 106, 106, 0.5);
+}
+
+.btn-lighter {
+  color: #3c3c3c;
+  background-color: #f9f9f9;
+  border-color: #f9f9f9;
+}
+.btn-lighter:hover {
+  color: #3c3c3c;
+  background-color: #e6e6e6;
+  border-color: #e0e0e0;
+}
+.btn-lighter:focus, .btn-lighter.focus {
+  box-shadow: 0 0 0 0.2rem rgba(221, 221, 221, 0.5);
+}
+.btn-lighter.disabled, .btn-lighter:disabled {
+  color: #3c3c3c;
+  background-color: #f9f9f9;
+  border-color: #f9f9f9;
+}
+.btn-lighter:not(:disabled):not(.disabled):active, .btn-lighter:not(:disabled):not(.disabled).active, .show > .btn-lighter.dropdown-toggle {
+  color: #3c3c3c;
+  background-color: #e0e0e0;
+  border-color: #d9d9d9;
+}
+.btn-lighter:not(:disabled):not(.disabled):active:focus, .btn-lighter:not(:disabled):not(.disabled).active:focus, .show > .btn-lighter.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(221, 221, 221, 0.5);
 }
 
 .btn-outline-primary {
@@ -2854,31 +2854,6 @@ fieldset:disabled a.btn {
   box-shadow: 0 0 0 0.2rem rgba(240, 240, 240, 0.5);
 }
 
-.btn-outline-lighter {
-  color: #f9f9f9;
-  border-color: #f9f9f9;
-}
-.btn-outline-lighter:hover {
-  color: #3c3c3c;
-  background-color: #f9f9f9;
-  border-color: #f9f9f9;
-}
-.btn-outline-lighter:focus, .btn-outline-lighter.focus {
-  box-shadow: 0 0 0 0.2rem rgba(249, 249, 249, 0.5);
-}
-.btn-outline-lighter.disabled, .btn-outline-lighter:disabled {
-  color: #f9f9f9;
-  background-color: transparent;
-}
-.btn-outline-lighter:not(:disabled):not(.disabled):active, .btn-outline-lighter:not(:disabled):not(.disabled).active, .show > .btn-outline-lighter.dropdown-toggle {
-  color: #3c3c3c;
-  background-color: #f9f9f9;
-  border-color: #f9f9f9;
-}
-.btn-outline-lighter:not(:disabled):not(.disabled):active:focus, .btn-outline-lighter:not(:disabled):not(.disabled).active:focus, .show > .btn-outline-lighter.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(249, 249, 249, 0.5);
-}
-
 .btn-outline-dark {
   color: #505050;
   border-color: #505050;
@@ -2902,6 +2877,31 @@ fieldset:disabled a.btn {
 }
 .btn-outline-dark:not(:disabled):not(.disabled):active:focus, .btn-outline-dark:not(:disabled):not(.disabled).active:focus, .show > .btn-outline-dark.dropdown-toggle:focus {
   box-shadow: 0 0 0 0.2rem rgba(80, 80, 80, 0.5);
+}
+
+.btn-outline-lighter {
+  color: #f9f9f9;
+  border-color: #f9f9f9;
+}
+.btn-outline-lighter:hover {
+  color: #3c3c3c;
+  background-color: #f9f9f9;
+  border-color: #f9f9f9;
+}
+.btn-outline-lighter:focus, .btn-outline-lighter.focus {
+  box-shadow: 0 0 0 0.2rem rgba(249, 249, 249, 0.5);
+}
+.btn-outline-lighter.disabled, .btn-outline-lighter:disabled {
+  color: #f9f9f9;
+  background-color: transparent;
+}
+.btn-outline-lighter:not(:disabled):not(.disabled):active, .btn-outline-lighter:not(:disabled):not(.disabled).active, .show > .btn-outline-lighter.dropdown-toggle {
+  color: #3c3c3c;
+  background-color: #f9f9f9;
+  border-color: #f9f9f9;
+}
+.btn-outline-lighter:not(:disabled):not(.disabled):active:focus, .btn-outline-lighter:not(:disabled):not(.disabled).active:focus, .show > .btn-outline-lighter.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(249, 249, 249, 0.5);
 }
 
 .btn-link {
@@ -4741,19 +4741,6 @@ a.badge-light:focus, a.badge-light.focus {
   box-shadow: 0 0 0 0.2rem rgba(240, 240, 240, 0.5);
 }
 
-.badge-lighter {
-  color: #3c3c3c;
-  background-color: #f9f9f9;
-}
-a.badge-lighter:hover, a.badge-lighter:focus {
-  color: #3c3c3c;
-  background-color: #e0e0e0;
-}
-a.badge-lighter:focus, a.badge-lighter.focus {
-  outline: 0;
-  box-shadow: 0 0 0 0.2rem rgba(249, 249, 249, 0.5);
-}
-
 .badge-dark {
   color: #fff;
   background-color: #505050;
@@ -4765,6 +4752,19 @@ a.badge-dark:hover, a.badge-dark:focus {
 a.badge-dark:focus, a.badge-dark.focus {
   outline: 0;
   box-shadow: 0 0 0 0.2rem rgba(80, 80, 80, 0.5);
+}
+
+.badge-lighter {
+  color: #3c3c3c;
+  background-color: #f9f9f9;
+}
+a.badge-lighter:hover, a.badge-lighter:focus {
+  color: #3c3c3c;
+  background-color: #e0e0e0;
+}
+a.badge-lighter:focus, a.badge-lighter.focus {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(249, 249, 249, 0.5);
 }
 
 .jumbotron {
@@ -4896,18 +4896,6 @@ a.badge-dark:focus, a.badge-dark.focus {
   color: #646464;
 }
 
-.alert-lighter {
-  color: #818181;
-  background-color: #fefefe;
-  border-color: #fdfdfd;
-}
-.alert-lighter hr {
-  border-top-color: #f0f0f0;
-}
-.alert-lighter .alert-link {
-  color: #686868;
-}
-
 .alert-dark {
   color: #2a2a2a;
   background-color: gainsboro;
@@ -4918,6 +4906,18 @@ a.badge-dark:focus, a.badge-dark.focus {
 }
 .alert-dark .alert-link {
   color: #111111;
+}
+
+.alert-lighter {
+  color: #818181;
+  background-color: #fefefe;
+  border-color: #fdfdfd;
+}
+.alert-lighter hr {
+  border-top-color: #f0f0f0;
+}
+.alert-lighter .alert-link {
+  color: #686868;
 }
 
 @-webkit-keyframes progress-bar-stripes {
@@ -5252,20 +5252,6 @@ a.badge-dark:focus, a.badge-dark.focus {
   border-color: #7d7d7d;
 }
 
-.list-group-item-lighter {
-  color: #818181;
-  background-color: #fdfdfd;
-}
-.list-group-item-lighter.list-group-item-action:hover, .list-group-item-lighter.list-group-item-action:focus {
-  color: #818181;
-  background-color: #f0f0f0;
-}
-.list-group-item-lighter.list-group-item-action.active {
-  color: #fff;
-  background-color: #818181;
-  border-color: #818181;
-}
-
 .list-group-item-dark {
   color: #2a2a2a;
   background-color: #cecece;
@@ -5278,6 +5264,20 @@ a.badge-dark:focus, a.badge-dark.focus {
   color: #fff;
   background-color: #2a2a2a;
   border-color: #2a2a2a;
+}
+
+.list-group-item-lighter {
+  color: #818181;
+  background-color: #fdfdfd;
+}
+.list-group-item-lighter.list-group-item-action:hover, .list-group-item-lighter.list-group-item-action:focus {
+  color: #818181;
+  background-color: #f0f0f0;
+}
+.list-group-item-lighter.list-group-item-action.active {
+  color: #fff;
+  background-color: #818181;
+  border-color: #818181;
 }
 
 .close {
@@ -6027,16 +6027,6 @@ button.bg-light:focus {
   background-color: #d7d7d7 !important;
 }
 
-.bg-lighter {
-  background-color: #f9f9f9 !important;
-}
-
-a.bg-lighter:hover, a.bg-lighter:focus,
-button.bg-lighter:hover,
-button.bg-lighter:focus {
-  background-color: #e0e0e0 !important;
-}
-
 .bg-dark {
   background-color: #505050 !important;
 }
@@ -6045,6 +6035,16 @@ a.bg-dark:hover, a.bg-dark:focus,
 button.bg-dark:hover,
 button.bg-dark:focus {
   background-color: #373737 !important;
+}
+
+.bg-lighter {
+  background-color: #f9f9f9 !important;
+}
+
+a.bg-lighter:hover, a.bg-lighter:focus,
+button.bg-lighter:hover,
+button.bg-lighter:focus {
+  background-color: #e0e0e0 !important;
 }
 
 .bg-white {
@@ -6123,12 +6123,12 @@ button.bg-dark:focus {
   border-color: #f0f0f0 !important;
 }
 
-.border-lighter {
-  border-color: #f9f9f9 !important;
-}
-
 .border-dark {
   border-color: #505050 !important;
+}
+
+.border-lighter {
+  border-color: #f9f9f9 !important;
 }
 
 .border-white {
@@ -6429,6 +6429,22 @@ button.bg-dark:focus {
   width: 100%;
   height: 100%;
   border: 0;
+}
+
+.embed-responsive-21by9::before {
+  padding-top: 42.8571428571%;
+}
+
+.embed-responsive-16by9::before {
+  padding-top: 56.25%;
+}
+
+.embed-responsive-4by3::before {
+  padding-top: 75%;
+}
+
+.embed-responsive-1by1::before {
+  padding-top: 100%;
 }
 
 .embed-responsive-21by9::before {
@@ -11507,20 +11523,20 @@ a.text-light:hover, a.text-light:focus {
   color: #cacaca !important;
 }
 
-.text-lighter {
-  color: #f9f9f9 !important;
-}
-
-a.text-lighter:hover, a.text-lighter:focus {
-  color: lightgray !important;
-}
-
 .text-dark {
   color: #505050 !important;
 }
 
 a.text-dark:hover, a.text-dark:focus {
   color: #2a2a2a !important;
+}
+
+.text-lighter {
+  color: #f9f9f9 !important;
+}
+
+a.text-lighter:hover, a.text-lighter:focus {
+  color: lightgray !important;
 }
 
 .text-body {

--- a/themes/custom/apigee_kickstart/src/components/navs/_nav-tabs-secondary.scss
+++ b/themes/custom/apigee_kickstart/src/components/navs/_nav-tabs-secondary.scss
@@ -3,8 +3,6 @@
 .nav-tabs--secondary {
   border-bottom: 1px solid $gray-400;
   font-size: .875rem;
-  flex-wrap: nowrap;
-  overflow: scroll;
 
   .nav-link {
     color: $gray-500;

--- a/themes/custom/apigee_kickstart/src/components/navs/_nav-tabs.scss
+++ b/themes/custom/apigee_kickstart/src/components/navs/_nav-tabs.scss
@@ -3,7 +3,7 @@
 .nav-tabs {
   border-left: 1px solid $gray-400;
   border-bottom: 1px solid $gray-400;
-  font-size: .875rem;
+  font-size: 0.875rem;
 
   .nav-item {
     margin: 0;
@@ -30,6 +30,14 @@
       color: $gray-900;
       border-bottom-color: var(--ak-accent-color);
 
+      .is-collapse-enabled & {
+        border-right-color:var(--ak-accent-color);
+      }
+
+      .is-horizontal & {
+        border-bottom-color: var(--ak-accent-color);
+      }
+
       &:after {
         content: "";
         height: 4px;
@@ -38,6 +46,7 @@
         left: 0;
         right: 0;
         bottom: 0;
+        z-index: 16;
       }
     }
   }

--- a/themes/custom/apigee_kickstart/src/components/navs/_tabs.scss
+++ b/themes/custom/apigee_kickstart/src/components/navs/_tabs.scss
@@ -1,0 +1,115 @@
+// Responsive Tabs
+// -----------------------------------------------------------------------------
+
+.is-collapse-enabled .nav-tabs,
+.is-horizontal .nav-tabs {
+  clear: both;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  position: relative;
+
+  // Bottom border should not affect overall container height.
+  &:before {
+    border-bottom: 1px solid $gray-400;
+    bottom: 0;
+    content: '';
+    display: block;
+    height: 1px;
+    left: 0;
+    position: absolute;
+    right: 0;
+    z-index: 10;
+  }
+}
+
+// Collapsed state
+.is-collapse-enabled .nav-tabs {
+  max-height: 0;
+  overflow: hidden;
+  padding-top: 40px;
+
+  &:before {
+    right: 60px;
+  }
+
+  &.is-open::before {
+    display: none;
+  }
+}
+
+// Collapsed and open.
+.nav-tabs.is-open {
+  max-height: 999em;
+}
+
+// Horizontal state
+.is-horizontal .nav-tabs {
+  overflow: visible;
+  max-height: none !important;
+  padding-top: 0 !important;
+  border-bottom: 0;
+}
+
+
+// Tab List Item
+// -----------------------------------------------------------------------------
+
+.nav-tabs .nav-item {
+  display: block;
+  overflow: hidden;
+  position: relative;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+// Show active item at the top of the list when collapsed.
+.is-collapse-enabled .nav-item.active {
+  position: absolute;
+  top: 0;
+  left: 0; /* LTR */
+  width: calc(100% - 60px);
+  z-index: 15;
+}
+
+.is-horizontal .nav-item {
+  float: left; /* LTR */
+  width: auto;
+  height: auto;
+  text-align: center;
+}
+
+// Override the states above
+// .is-horizontal .nav-tabs.nav-tabs--primary .nav-item.active
+.is-horizontal .nav-item.active,
+.is-horizontal .nav-tabs.nav-tabs--primary .nav-item.active {
+  position: relative;
+  top: 0;
+  width: auto;
+}
+
+
+// Tab Trigger & Nav Positining
+// -----------------------------------------------------------------------------
+
+.tabs__trigger,
+.is-horizontal .tabs__trigger {
+  display: none;
+}
+
+/* JS dependent styling */
+.is-collapse-enabled .tabs__trigger {
+  background: var(--ak-accent-color);
+  border: 0;
+  color: var(--ak-accent-color-light);
+  display: block;
+  height: 40px;
+  left: auto;
+  outline: 0;
+  position: absolute;
+  right: 0;
+  text-align: center;
+  top: 0;
+  width: 60px;
+  z-index: 10;
+}

--- a/themes/custom/apigee_kickstart/src/sass/apigee-kickstart.style.scss
+++ b/themes/custom/apigee_kickstart/src/sass/apigee-kickstart.style.scss
@@ -85,6 +85,7 @@
 @import "../components/text-image/text-image";
 @import "../components/navs/nav-tabs";
 @import "../components/navs/nav-tabs-secondary";
+@import "../components/navs/tabs";
 @import "../components/secret/secret";
 @import "../components/table/table";
 @import "../components/title-bar/title-bar";

--- a/themes/custom/apigee_kickstart/templates/menu/menu-local-task.html.twig
+++ b/themes/custom/apigee_kickstart/templates/menu/menu-local-task.html.twig
@@ -1,0 +1,14 @@
+{#
+/**
+ * @file
+ * Template for a local task link.
+ *
+ * - nav-item is for styling.
+ * - .tabs__tab is used to determine height via JavaScript in respnonsive
+ *   implementation.
+ */
+#}
+{% set active = is_active ? 'active' : '' %}
+<li{{ attributes.addClass('nav-item', 'tabs__tab', active) }}>
+  <a href="{{ link['#url'] }}" class="nav-link {{ active }}">{{ link['#title'] }}</a>
+</li>

--- a/themes/custom/apigee_kickstart/templates/menu/menu-local-tasks.html.twig
+++ b/themes/custom/apigee_kickstart/templates/menu/menu-local-tasks.html.twig
@@ -2,13 +2,69 @@
 /**
  * @file
  * Template primary and secondary local tasks.
+ *
+ * This theme uses the seven/drupal.nav-tabs library implementation for
+ * responsive tabs. The option to toggling between horizontal and vertical view
+ * is currently supported via CSS for Primary tabs. The script detects wrapping
+ * automatically, by comparing the height of the container to the height of the
+ * list item, instead of using media queries/breakpoints. As a result, you can
+ * style them normally, and when the height of the container exceeds that of a
+ * single <li>, the .is-horizontal class is removed and .is-collapse-enabled is
+ * added. Key attributes, classes and states are described below:
+ *
+ * Data Attributes
+ * ---------------
+ *
+ * - [data-tabs]: Applies to the container (nav) of the tabs list.
+ * - [data-tabs-target]: Applies to the (ul) element containing the tabs.
+ *   Required for .is-collapsible option.
+ * - [data-tabs-trigger]: The trigger <button>. Required for .is-collapsible
+ *   option.
+ *
+ * Options
+ * -------
+ *
+ * - .is-collapsible: Add this class on the same element as [data-tabs] if you
+ *   want the tabs to collapse to a single item (the active one), when the state
+ *   is NOT horizontal. Without this the tabs will just toggle the
+ *   .is-horizontal class.
+ *
+ * States
+ * ------
+ *
+ * Added via Markup:
+ *
+ * - li.active: Required for .is-collapsible implementation on at least one
+ *   tab <li>, as this determines which item shows beside the toggle button when
+ *   the tabs are collapsed.
+ *
+ * Added via JavaScript:
+ *
+ * - .is-horizontal-enabled: Indeicates the script is active and listening for
+ *   changes on resize.
+ * - .is-horitonzal: Indicates the tabs are currently horizontal. This is true
+ *   when the height of the <ul> does not exceed the height of the
+ *    li.tabs__tab element.
+ * - .is-collapsed-enabled: Opposite of .is-horizontal, indicates the the tabs
+ *    are currently collapsed.
+ * - .is-open: Works with .is-collapsible. When the list is collapsed, and the
+ *    trigger has been clicked, this class is added to the [data-tabs-target]
+ *    list element.
+ *
  */
 #}
+{{ attach_library('seven/drupal.nav-tabs') }}
+
 {% if primary %}
-  <h2 class="visually-hidden">{{ 'Primary tabs'|t }}</h2>
-  <ul class="nav nav-tabs mb-3">{{ primary }}</ul>
+  <h2 class="visually-hidden" id="primary-tabs-title">{{ 'Primary tabs'|t }}</h2>
+  <nav aria-labelledby="primary-tabs-title" class="is-horizontal is-collapsible mb-3" data-drupal-nav-tabs role="navigation">
+    <button class="reset-appearance tabs__trigger" aria-label="{{ 'Primary tabs display toggle'|t }}" data-drupal-nav-tabs-trigger>&bull;&bull;&bull;</button>
+    <ul class="tabs nav-tabs nav-tabs--primary clearfix" data-drupal-nav-tabs-target>{{ primary }}</ul>
+  </nav>
 {% endif %}
 {% if secondary %}
-  <h2 class="visually-hidden">{{ 'Secondary tabs'|t }}</h2>
-  <ul class="nav nav-tabs--secondary">{{ secondary }}</ul>
+  <h2 class="visually-hidden" id="secondary-tabs-title">{{ 'Secondary tabs'|t }}</h2>
+  <nav aria-labelledby="secondary-tabs-title" class="is-horizontal mb-3" data-drupal-nav-tabs role="navigation">
+    <ul class="tabs nav nav-tabs--secondary clearfix">{{ secondary }}</ul>
+  </nav>
 {% endif %}


### PR DESCRIPTION
## Tabs Collapsed
Default state when there is not enough room to display all on a single line.

<img width="555" alt="tabs-collapsed-default" src="https://user-images.githubusercontent.com/60979/58112343-4f3fda00-7bc1-11e9-8aab-c868d44d4138.png">

## Tabs Collapsed & Expanded
<img width="549" alt="tabs-collapsed-expanded" src="https://user-images.githubusercontent.com/60979/58112345-4f3fda00-7bc1-11e9-8847-cebcd25a4e37.png">

## Horizontal state
Tabs will display this way until there is no longer enough room to display them on a single line.

<img width="982" alt="tabs-horitonzal" src="https://user-images.githubusercontent.com/60979/58112344-4f3fda00-7bc1-11e9-9fd2-b0b8b0e2de07.png">
