### PR TITLE
Add an event subscriber to redirect to apidoc canonical page on not found exception

### DIFF
--- a/modules/custom/apigee_kickstart_enhancement/apigee_kickstart_enhancement.services.yml
+++ b/modules/custom/apigee_kickstart_enhancement/apigee_kickstart_enhancement.services.yml
@@ -7,7 +7,7 @@ services:
 
   apigee_kickstart_enhancement.page_not_found_subscriber:
     class: Drupal\apigee_kickstart_enhancement\EventSubscriber\PageNotFoundEventSubscriber
-    arguments: ['@path.validator']
+    arguments: ['@path.matcher', '@path.validator']
     tags:
       - { name: event_subscriber }
 

--- a/modules/custom/apigee_kickstart_enhancement/apigee_kickstart_enhancement.services.yml
+++ b/modules/custom/apigee_kickstart_enhancement/apigee_kickstart_enhancement.services.yml
@@ -5,6 +5,12 @@ services:
       - { name: event_subscriber }
     arguments: ['@apigee_kickstart.enhancer']
 
+  apigee_kickstart_enhancement.page_not_found_subscriber:
+    class: Drupal\apigee_kickstart_enhancement\EventSubscriber\PageNotFoundEventSubscriber
+    arguments: ['@path.validator']
+    tags:
+      - { name: event_subscriber }
+
   apigee_kickstart.enhancer:
     class: Drupal\apigee_kickstart_enhancement\ApigeeKickStartEnhancer
     arguments: ['@entity_type.manager']

--- a/modules/custom/apigee_kickstart_enhancement/src/EventSubscriber/PageNotFoundEventSubscriber.php
+++ b/modules/custom/apigee_kickstart_enhancement/src/EventSubscriber/PageNotFoundEventSubscriber.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_kickstart_enhancement\EventSubscriber;
+
+use Drupal\Core\Path\PathValidatorInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Handles not found exceptions for apidoc entities.
+ *
+ * @package Drupal\apigee_kickstart_enhancement\EventSubscriber
+ */
+class PageNotFoundEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The path validator service.
+   *
+   * @var \Drupal\Core\Path\PathValidatorInterface
+   */
+  protected $pathValidator;
+
+  /**
+   * PageNotFoundEventSubscriber constructor.
+   *
+   * @param \Drupal\Core\Path\PathValidatorInterface $path_validator
+   *   The path validator service.
+   */
+  public function __construct(PathValidatorInterface $path_validator) {
+    $this->pathValidator = $path_validator;
+  }
+
+  /**
+   * Redirects to the apidoc canonical route if we have a not found exception.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent $event
+   *   The exception event.
+   */
+  public function onNotFoundException(GetResponseForExceptionEvent $event) {
+    $path = NULL;
+
+    // Check if the request uri matches an apidoc canonical route.
+    // Also check for apidoc valid path.
+    if (!($event->getException() instanceof NotFoundHttpException)
+      || !(preg_match('/^\/api\/([0-9]+)\/.+$/', $event->getRequest()->getRequestUri(), $matches)
+        && ($path = "/api/{$matches[1]}")
+        && $this->pathValidator->isValid($path))
+    ) {
+      return;
+    }
+
+    // Redirect to the apidoc.
+    $event->setResponse(new RedirectResponse($path));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[KernelEvents::EXCEPTION][] = ['onNotFoundException', 0];
+    return $events;
+  }
+
+}


### PR DESCRIPTION
This is a fix that implements an event subscriber to redirect back to an `apidoc` canonical page on not found exception. It checks for `/api/ID/foo/bar` uri and validates `/api/ID` paths and redirect to that.

This can be a temp fix for the page not found issue on apidocs. Instead of seeing a page not found on refresh, the user sees the overview for the smartdocs.