### PR TITLE
Remove "--stability dev" from install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The core functionality of this profile is in active development. The features an
 The following command will download Drupal core, the Apigee Developer Portal Kickstart profile, and their dependencies, into the `MY_PROJECT` directory:
 
 ```sh
-composer create-project apigee/devportal-kickstart-project:8.x-dev MY_PROJECT --stability dev --no-interaction
+composer create-project apigee/devportal-kickstart-project:8.x-dev MY_PROJECT --no-interaction
 ```
 
 The actual web root will be `MY_PROJECT/web`. You will need to point your [web server](https://www.drupal.org/docs/develop/local-server-setup) to serve that directory. Then, visit the site in a web browser, and you'll be redirected to `core/install.php`, where you can run the installer like any Drupal site installation. Running the installation via web browser is recommended for the best experience.


### PR DESCRIPTION
The `--stability dev` is redundant, see: https://github.com/drupal-composer/drupal-project/issues/449