### PR TITLE
#174: Only target .nav-link, so as not to affect the dropdown links.

### DIFF
--- a/themes/custom/apigee_kickstart/assets/css/apigee-kickstart.style.css
+++ b/themes/custom/apigee_kickstart/assets/css/apigee-kickstart.style.css
@@ -12338,7 +12338,7 @@ fieldset.closed legend button {
   font-size: 0.875rem;
   flex-shrink: 0;
 }
-.navbar a, .navbar .nav-link {
+.navbar .nav-link {
   color: var(--ak-header-color);
 }
 @media (max-width: 991.98px) {

--- a/themes/custom/apigee_kickstart/src/components/navbar/_navbar.scss
+++ b/themes/custom/apigee_kickstart/src/components/navbar/_navbar.scss
@@ -7,7 +7,7 @@
   font-size: 0.875rem;
   flex-shrink: 0;
 
-  a, .nav-link {
+  .nav-link {
     color: var(--ak-header-color);
   }
 


### PR DESCRIPTION
Fixes #174.

## Before
<img width="197" alt="Screen Shot 2019-07-02 at 9 13 30 AM" src="https://user-images.githubusercontent.com/60979/60522665-6d682200-9cb7-11e9-90eb-ce1e495f4251.png">


## After
<img width="228" alt="Screen Shot 2019-07-02 at 10 50 28 AM" src="https://user-images.githubusercontent.com/60979/60522606-50cbea00-9cb7-11e9-95b1-b095bf3c21be.png">

With customized colors...
<img width="251" alt="Screen Shot 2019-07-02 at 10 47 29 AM" src="https://user-images.githubusercontent.com/60979/60522609-51fd1700-9cb7-11e9-8c77-29eb35381209.png">
