### PR TITLE
#172: Add asterisk for required form elements.

### DIFF
--- a/themes/custom/apigee_kickstart/assets/css/apigee-kickstart.style.css
+++ b/themes/custom/apigee_kickstart/assets/css/apigee-kickstart.style.css
@@ -13006,6 +13006,16 @@ ul.social-links li a {
   align-items: stretch;
 }
 
+label {
+  vertical-align: middle;
+}
+
+.form-required__indicator {
+  display: inline-block;
+  font-size: 0.5rem;
+  vertical-align: text-top;
+}
+
 .contact-message-form .form-item-copy {
   margin-top: 1.5rem;
 }

--- a/themes/custom/apigee_kickstart/src/sass/apigee-kickstart.style.scss
+++ b/themes/custom/apigee_kickstart/src/sass/apigee-kickstart.style.scss
@@ -99,6 +99,7 @@
 @import "apigee/smartdocs";
 @import "apigee/swagger";
 @import "block/block";
+@import "form/form";
 @import "form/form.contact";
 @import "form/form.search-form";
 @import "form/form.user";

--- a/themes/custom/apigee_kickstart/src/sass/form/_form.scss
+++ b/themes/custom/apigee_kickstart/src/sass/form/_form.scss
@@ -1,0 +1,9 @@
+label {
+  vertical-align: middle;
+}
+
+.form-required__indicator {
+  display: inline-block;
+  font-size: 0.5rem;
+  vertical-align: text-top;
+}

--- a/themes/custom/apigee_kickstart/templates/form/form-element-label.html.twig
+++ b/themes/custom/apigee_kickstart/templates/form/form-element-label.html.twig
@@ -1,0 +1,32 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a form element label.
+ *
+ * Available variables:
+ * - title: The label's text.
+ * - title_display: Elements title_display setting.
+ * - required: An indicator for whether the associated form element is required.
+ * - attributes: A list of HTML attributes for the label.
+ *
+ * @see template_preprocess_form_element_label()
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set classes = [
+    title_display == 'after' ? 'option',
+    title_display == 'invisible' ? 'visually-hidden',
+    required ? 'js-form-required',
+    required ? 'form-required',
+  ]
+%}
+{% if title is not empty or required -%}
+  <label{{ attributes.addClass(classes) }}>
+    {{ title }}
+    {% if required %}
+      <i class="fas fa-asterisk text-danger form-required__indicator"></i>
+    {% endif %}
+  </label>
+{%- endif %}


### PR DESCRIPTION
Fixes #172.



![contact](https://user-images.githubusercontent.com/60979/60526523-845e4280-9cbe-11e9-966d-285741adf5a6.png)
![user-login](https://user-images.githubusercontent.com/60979/60526524-845e4280-9cbe-11e9-858c-0ed33d7201ea.png)
![user-pass](https://user-images.githubusercontent.com/60979/60526525-845e4280-9cbe-11e9-9c3b-2288383b98e3.png)
![user-register](https://user-images.githubusercontent.com/60979/60526526-845e4280-9cbe-11e9-9b9d-74b26dd01270.png)
