### PR TITLE
[#206]: Set enforced config on “Pricing and Plans” title bar.

### DIFF
--- a/themes/custom/apigee_kickstart/config/optional/block.block.apigee_kickstart_title_bar_pricing_plans.yml
+++ b/themes/custom/apigee_kickstart/config/optional/block.block.apigee_kickstart_title_bar_pricing_plans.yml
@@ -5,6 +5,7 @@ dependencies:
     - 'block_content:title_bar:f2a03392-4abc-4f25-9f35-e28e63bb1a88'
   enforced:
     module:
+      - apigee_m10n
       - apigee_kickstart_content
   module:
     - block_content

--- a/themes/custom/apigee_kickstart/config/optional/block.block.apigee_kickstart_title_bar_pricing_plans.yml
+++ b/themes/custom/apigee_kickstart/config/optional/block.block.apigee_kickstart_title_bar_pricing_plans.yml
@@ -3,6 +3,9 @@ status: true
 dependencies:
   content:
     - 'block_content:title_bar:f2a03392-4abc-4f25-9f35-e28e63bb1a88'
+  enforced:
+    module:
+      - apigee_kickstart_content
   module:
     - block_content
     - system


### PR DESCRIPTION
Follow up for #205, which was originally done on 8.x-1.x before m10n branch was merged. 

Fixes #206.