### PR TITLE
[#220] Add note that Monetization in Kickstart is experimental

### DIFF
--- a/modules/custom/apigee_kickstart_m10n_add_credit/apigee_kickstart_m10n_add_credit.info.yml
+++ b/modules/custom/apigee_kickstart_m10n_add_credit/apigee_kickstart_m10n_add_credit.info.yml
@@ -2,7 +2,7 @@ name: Apigee Kickstart Monetization
 description: "Handles monetization for Apigee Kickstart. Adds and configures a default product type for adding credit."
 type: module
 core: 8.x
-package: Apigee Kickstart
+package: Apigee Kickstart (Experimental)
 dependencies:
   - apigee_m10n:apigee_m10n
   - apigee_m10n_add_credit:apigee_m10n_add_credit

--- a/src/Installer/Form/ApigeeMonetizationConfigurationForm.php
+++ b/src/Installer/Form/ApigeeMonetizationConfigurationForm.php
@@ -156,6 +156,17 @@ class ApigeeMonetizationConfigurationForm extends FormBase {
 
     $form['#title'] = $this->t('Configure monetization');
 
+    // Note that apigee_m10n is experimental.
+    $form['help'] = [
+      '#theme' => 'status_messages',
+      '#message_list' => [
+        MessengerInterface::TYPE_WARNING => [
+          $this->t('Note: Apigee Monetization in Kickstart is currently experimental.'),
+        ],
+      ],
+      '#weight' => -100,
+    ];
+
     $form['actions']['#type'] = 'actions';
     $form['actions']['submit'] = [
       '#type' => 'submit',


### PR DESCRIPTION
This will be removed shortly after apigee_m10n 1.0 is released.

Fixes #220.

## Installer Note
<img width="1409" alt="Installer Note stating that M10n support in Kickstart is still experimental" src="https://user-images.githubusercontent.com/60979/61317311-c3b58480-a7d0-11e9-9206-1410f75bd0a2.png">
