### PR TITLE
[#211] Refactor customizer to use files

### DIFF
--- a/modules/custom/apigee_kickstart_customizer/apigee_kickstart_customizer.module
+++ b/modules/custom/apigee_kickstart_customizer/apigee_kickstart_customizer.module
@@ -87,32 +87,29 @@ function apigee_kickstart_customizer_toolbar() {
 }
 
 /**
- * Implements hook_page_attachments_alter().
+ * Implements hook_page_attachments().
  */
-function apigee_kickstart_customizer_page_attachments_alter(array &$attachments) {
-  // TODO: Move this to a service.
-  if ($theme = Drupal::theme()->getActiveTheme()->getName()) {
-    if ($values = Drupal::configFactory()
-      ->get('apigee_kickstart_customizer.theme.' . $theme)
-      ->get('values')) {
+function apigee_kickstart_customizer_page_attachments(array &$attachments) {
+  if (($theme = Drupal::theme()->getActiveTheme()->getName()) && (Drupal::service('apigee_kickstart_customizer')->isCustomizable($theme))) {
+    $attachments['#attached']['library'][] = "$theme/customizer";
+  }
+}
 
-      // TODO: Add scope support.
-      $css = 'body {';
-      foreach ($values as $name => $value) {
-        if ($value) {
-          $css .= "$name: $value;";
-        }
-      }
-      $css .= '}';
-
-      $attachments['#attached']['html_head'][] = [
-        [
-          '#tag' => 'style',
-          '#weight' => 1000,
-          '#value' => $css,
+/**
+ * Implements hook_library_info_alter().
+ */
+function apigee_kickstart_customizer_library_info_alter(&$libraries, $extension) {
+  if (($theme = Drupal::theme()->getActiveTheme()->getName())
+    && (Drupal::service('apigee_kickstart_customizer')->isCustomizable($theme))
+    && ($extension === $theme)) {
+    $libraries['customizer'] = [
+      'css' => [
+        'theme' => [
+          "public://apigee_kickstart_customizer.$theme.css" => [
+            'weight' => 1000,
+          ],
         ],
-        'customizer-css',
-      ];
-    }
+      ],
+    ];
   }
 }

--- a/modules/custom/apigee_kickstart_customizer/apigee_kickstart_customizer.module
+++ b/modules/custom/apigee_kickstart_customizer/apigee_kickstart_customizer.module
@@ -90,6 +90,7 @@ function apigee_kickstart_customizer_toolbar() {
  * Implements hook_page_attachments().
  */
 function apigee_kickstart_customizer_page_attachments(array &$attachments) {
+  // Add the theme customizer library.
   if (($theme = Drupal::theme()->getActiveTheme()->getName()) && (Drupal::service('apigee_kickstart_customizer')->isCustomizable($theme))) {
     $attachments['#attached']['library'][] = "$theme/customizer";
   }
@@ -99,6 +100,7 @@ function apigee_kickstart_customizer_page_attachments(array &$attachments) {
  * Implements hook_library_info_alter().
  */
 function apigee_kickstart_customizer_library_info_alter(&$libraries, $extension) {
+  // Implement a library on behalf of the customizable theme.
   if (($theme = Drupal::theme()->getActiveTheme()->getName())
     && (Drupal::service('apigee_kickstart_customizer')->isCustomizable($theme))
     && ($extension === $theme)) {

--- a/modules/custom/apigee_kickstart_customizer/apigee_kickstart_customizer.services.yml
+++ b/modules/custom/apigee_kickstart_customizer/apigee_kickstart_customizer.services.yml
@@ -2,3 +2,9 @@ services:
   apigee_kickstart_customizer:
     class: Drupal\apigee_kickstart_customizer\Customizer
     arguments: ['@theme.manager', '@theme_handler', '@file_system', '@config.factory', '@asset.css.collection_optimizer']
+
+  apigee_kickstart_customizer.config_event_subscriber:
+    class: Drupal\apigee_kickstart_customizer\EventSubscriber\ConfigEventsSubscriber
+    arguments: ['@apigee_kickstart_customizer']
+    tags:
+      - { name: event_subscriber }

--- a/modules/custom/apigee_kickstart_customizer/apigee_kickstart_customizer.services.yml
+++ b/modules/custom/apigee_kickstart_customizer/apigee_kickstart_customizer.services.yml
@@ -1,4 +1,4 @@
 services:
   apigee_kickstart_customizer:
     class: Drupal\apigee_kickstart_customizer\Customizer
-    arguments: ['@theme.manager', '@theme_handler']
+    arguments: ['@theme.manager', '@theme_handler', '@file_system', '@config.factory', '@asset.css.collection_optimizer']

--- a/modules/custom/apigee_kickstart_customizer/phpcs.xml.dist
+++ b/modules/custom/apigee_kickstart_customizer/phpcs.xml.dist
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+
+<ruleset name="Apigee Devportal Kickstart coding standards">
+  <exclude-pattern>*/.git/*</exclude-pattern>
+  <exclude-pattern>*/config/*</exclude-pattern>
+  <exclude-pattern>*/css/*</exclude-pattern>
+  <exclude-pattern>*/js/*</exclude-pattern>
+  <exclude-pattern>*/vendor/*</exclude-pattern>
+  <exclude-pattern>\.md</exclude-pattern>
+
+  <rule ref="Drupal"/>
+
+  <!-- Copyright header must be visible on all PHP files, including classes in a namespace. -->
+  <rule ref="Drupal.Commenting.FileComment.NamespaceNoFileDoc">
+    <severity>0</severity>
+  </rule>
+  <!-- Annotation classes still contains snake case variable names. -->
+  <rule ref="Drupal.NamingConventions.ValidVariableName.LowerCamelName">
+    <severity>0</severity>
+  </rule>
+
+</ruleset>

--- a/modules/custom/apigee_kickstart_customizer/src/Customizer.php
+++ b/modules/custom/apigee_kickstart_customizer/src/Customizer.php
@@ -172,7 +172,6 @@ class Customizer extends DefaultPluginManager implements CustomizerInterface {
     Cache::invalidateTags(['library_info']);
   }
 
-
   /**
    * {@inheritdoc}
    */

--- a/modules/custom/apigee_kickstart_customizer/src/Customizer.php
+++ b/modules/custom/apigee_kickstart_customizer/src/Customizer.php
@@ -20,9 +20,13 @@
 
 namespace Drupal\apigee_kickstart_customizer;
 
+use Drupal\Core\Asset\AssetCollectionOptimizerInterface;
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Discovery\YamlDiscovery;
 use Drupal\Core\Extension\Extension;
 use Drupal\Core\Extension\ThemeHandlerInterface;
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
 use Drupal\Core\Theme\ThemeManagerInterface;
 
@@ -53,17 +57,47 @@ class Customizer extends DefaultPluginManager implements CustomizerInterface {
   protected $activeTheme;
 
   /**
+   * The file system service.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  protected $fileSystem;
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * The asset collection optimizer.
+   *
+   * @var \Drupal\Core\Asset\AssetCollectionOptimizerInterface
+   */
+  protected $collectionOptimizer;
+
+  /**
    * CustomizerThemeHandler constructor.
    *
    * @param \Drupal\Core\Theme\ThemeManagerInterface $theme_manager
    *   The theme manager.
    * @param \Drupal\Core\Extension\ThemeHandlerInterface $theme_handler
    *   The theme handler.
+   * @param \Drupal\Core\File\FileSystemInterface $file_system
+   *   The file system service.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   * @param \Drupal\Core\Asset\AssetCollectionOptimizerInterface $collection_optimizer
+   *   The asset collection optimizer.
    */
-  public function __construct(ThemeManagerInterface $theme_manager, ThemeHandlerInterface $theme_handler) {
+  public function __construct(ThemeManagerInterface $theme_manager, ThemeHandlerInterface $theme_handler, FileSystemInterface $file_system, ConfigFactoryInterface $config_factory, AssetCollectionOptimizerInterface $collection_optimizer) {
     $this->themeManager = $theme_manager;
     $this->themeHandler = $theme_handler;
     $this->activeTheme = $this->themeManager->getActiveTheme();
+    $this->fileSystem = $file_system;
+    $this->configFactory = $config_factory;
+    $this->collectionOptimizer = $collection_optimizer;
   }
 
   /**
@@ -112,6 +146,32 @@ class Customizer extends DefaultPluginManager implements CustomizerInterface {
     $definitions = $this->getDefinitions();
     return isset($definitions[$theme]) ? $definitions[$theme] : [];
   }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function updateStylesheetForTheme($theme = NULL): void {
+    $theme = $theme ?? $this->activeTheme->getName();
+    $values = $this->configFactory->get('apigee_kickstart_customizer.theme.' . $theme)
+      ->get('values');
+
+    // TODO: Add scope support.
+    $css = ':root {';
+    foreach ($values as $name => $value) {
+      if ($value) {
+        $css .= "$name: $value;";
+      }
+    }
+    $css .= '}';
+
+    // Save value to file.
+    $this->fileSystem->saveData($css, "public://apigee_kickstart_customizer.$theme.css", FileSystemInterface::EXISTS_REPLACE);
+
+    // Rebuild caches.
+    $this->collectionOptimizer->deleteAll();
+    Cache::invalidateTags(['library_info']);
+  }
+
 
   /**
    * {@inheritdoc}

--- a/modules/custom/apigee_kickstart_customizer/src/Customizer.php
+++ b/modules/custom/apigee_kickstart_customizer/src/Customizer.php
@@ -175,6 +175,19 @@ class Customizer extends DefaultPluginManager implements CustomizerInterface {
   /**
    * {@inheritdoc}
    */
+  public function deleteStylesheetForTheme($theme = NULL): void {
+    $theme = $theme ?? $this->activeTheme->getName();
+
+    $this->fileSystem->delete("public://apigee_kickstart_customizer.$theme.css");
+
+    // Rebuild caches.
+    $this->collectionOptimizer->deleteAll();
+    Cache::invalidateTags(['library_info']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getConfig($theme = NULL): array {
     $theme = $theme ?? $this->activeTheme->getName();
 

--- a/modules/custom/apigee_kickstart_customizer/src/CustomizerInterface.php
+++ b/modules/custom/apigee_kickstart_customizer/src/CustomizerInterface.php
@@ -64,6 +64,14 @@ interface CustomizerInterface {
   public function updateStylesheetForTheme($theme = NULL): void;
 
   /**
+   * Deletes the stylesheet for a theme.
+   *
+   * @param string $theme
+   *   The name of the theme.
+   */
+  public function deleteStylesheetForTheme($theme = NULL): void;
+
+  /**
    * Returns customizer config for a theme.
    *
    * @param string $theme

--- a/modules/custom/apigee_kickstart_customizer/src/CustomizerInterface.php
+++ b/modules/custom/apigee_kickstart_customizer/src/CustomizerInterface.php
@@ -58,7 +58,7 @@ interface CustomizerInterface {
   /**
    * Updates the stylesheet for a theme.
    *
-   * @param null $theme
+   * @param string $theme
    *   The name of the theme.
    */
   public function updateStylesheetForTheme($theme = NULL): void;

--- a/modules/custom/apigee_kickstart_customizer/src/CustomizerInterface.php
+++ b/modules/custom/apigee_kickstart_customizer/src/CustomizerInterface.php
@@ -56,6 +56,14 @@ interface CustomizerInterface {
   public function getDefinitionForTheme($theme = NULL): array;
 
   /**
+   * Updates the stylesheet for a theme.
+   *
+   * @param null $theme
+   *   The name of the theme.
+   */
+  public function updateStylesheetForTheme($theme = NULL): void;
+
+  /**
    * Returns customizer config for a theme.
    *
    * @param string $theme

--- a/modules/custom/apigee_kickstart_customizer/src/EventSubscriber/ConfigEventsSubscriber.php
+++ b/modules/custom/apigee_kickstart_customizer/src/EventSubscriber/ConfigEventsSubscriber.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Copyright 2019 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_kickstart_customizer\EventSubscriber;
+
+use Drupal\apigee_kickstart_customizer\CustomizerInterface;
+use Drupal\Core\Config\ConfigCrudEvent;
+use Drupal\Core\Config\ConfigEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * An event subscriber to re-create stylesheet when config is updated.
+ */
+class ConfigEventsSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The customizer service.
+   *
+   * @var \Drupal\apigee_kickstart_customizer\CustomizerInterface
+   */
+  protected $customizer;
+
+  /**
+   * ConfigEventsSubscriber constructor.
+   *
+   * @param \Drupal\apigee_kickstart_customizer\CustomizerInterface $customizer
+   *   The customizer service.
+   */
+  public function __construct(CustomizerInterface $customizer) {
+    $this->customizer = $customizer;
+  }
+
+  /**
+   * Re-create stylesheet for theme when config is updated.
+   *
+   * @param \Drupal\Core\Config\ConfigCrudEvent $event
+   *   The config event.
+   */
+  public function onChange(ConfigCrudEvent $event) {
+    if (preg_match('/^apigee_kickstart_customizer\.theme\.([^\.]*)$/', $event->getConfig()->getName(), $matches)) {
+      $this->customizer->updateStylesheetForTheme($matches[1]);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[ConfigEvents::SAVE][] = ['onChange'];
+    $events[ConfigEvents::DELETE][] = ['onChange'];
+
+    return $events;
+  }
+
+}

--- a/modules/custom/apigee_kickstart_customizer/src/EventSubscriber/ConfigEventsSubscriber.php
+++ b/modules/custom/apigee_kickstart_customizer/src/EventSubscriber/ConfigEventsSubscriber.php
@@ -48,14 +48,26 @@ class ConfigEventsSubscriber implements EventSubscriberInterface {
   }
 
   /**
-   * Re-create stylesheet for theme when config is updated.
+   * Re-creates stylesheet for theme when config is updated.
    *
    * @param \Drupal\Core\Config\ConfigCrudEvent $event
    *   The config event.
    */
-  public function onChange(ConfigCrudEvent $event) {
+  public function onSave(ConfigCrudEvent $event) {
     if (preg_match('/^apigee_kickstart_customizer\.theme\.([^\.]*)$/', $event->getConfig()->getName(), $matches)) {
       $this->customizer->updateStylesheetForTheme($matches[1]);
+    }
+  }
+
+  /**
+   * Removes stylesheet for theme when config is deleted.
+   *
+   * @param \Drupal\Core\Config\ConfigCrudEvent $event
+   *   The config event.
+   */
+  public function onDelete(ConfigCrudEvent $event) {
+    if (preg_match('/^apigee_kickstart_customizer\.theme\.([^\.]*)$/', $event->getConfig()->getName(), $matches)) {
+      $this->customizer->deleteStylesheetForTheme($matches[1]);
     }
   }
 
@@ -63,8 +75,8 @@ class ConfigEventsSubscriber implements EventSubscriberInterface {
    * {@inheritdoc}
    */
   public static function getSubscribedEvents() {
-    $events[ConfigEvents::SAVE][] = ['onChange'];
-    $events[ConfigEvents::DELETE][] = ['onChange'];
+    $events[ConfigEvents::SAVE][] = ['onSave'];
+    $events[ConfigEvents::DELETE][] = ['onDelete'];
 
     return $events;
   }

--- a/modules/custom/apigee_kickstart_customizer/src/Form/CustomizerForm.php
+++ b/modules/custom/apigee_kickstart_customizer/src/Form/CustomizerForm.php
@@ -166,8 +166,11 @@ class CustomizerForm extends ConfigFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $form_state->cleanValues();
     $values = $form_state->getValues();
-    $this->configFactory->getEditable('apigee_kickstart_customizer.theme.' . $form_state->get('theme'))
+    $theme = $form_state->get('theme');
+    $this->configFactory->getEditable('apigee_kickstart_customizer.theme.' . $theme)
       ->set('values', $values)->save();
+
+    $this->customizer->updateStylesheetForTheme($theme);
 
     parent::submitForm($form, $form_state);
   }


### PR DESCRIPTION
Fixes #211 

This PR refactors the customizer to save to a generated CSS file instead of inline style. The generated CSS file is then put into a library that the module creates on behalf of the customizable theme.

This allows the weight of the file to be set and can be moved down to overwrite any variables set by other files (example the theme CSS file).

As a side effect, caching of the file is handled for us 👍 .

I added an event subscriber to re-generate the CSS file when config is updated. This way if you change values on local and import to another environment, an updated CSS file is created for you.