### PR TITLE
[#127] Starter kit and sub theming docs

### DIFF
--- a/themes/custom/apigee_kickstart/README.md
+++ b/themes/custom/apigee_kickstart/README.md
@@ -1,20 +1,58 @@
 # Apigee Kickstart theme
 
-## Installation
-`apigee_kickstart` theme uses [Webpack](https://webpack.js.org) to compile and bundle SASS and JS.
+The Apigee Kickstart theme uses the [Radix](https://drupal.org/project/radix) as its base theme. There are two different ways you can customize the look and feel of this theme:
 
-### Step 1
-Make sure you have Node and npm installed.
-You can read a guide on how to install node here: https://docs.npmjs.com/getting-started/installing-node
+1. **Customize the color scheme in the user interface**: It's possible to customize the color scheme used in this theme without writing any code. When logged in as a privileged user with `apigee_kickstart` enabled as the default theme, you'll see a **Customize** link in the Toolbar on the front end of the site. Clicking the **Customize** link opens the Settings Tray, which contains 7 color fields, which you can edit using a color wheel. Use these fields to customize the colors for the site header, footer, and accents, such as buttons and icons.
+2. **Customizing in code by creating a subtheme**: If you'd like to add or make adjustments to templates, CSS or JavaScript, it is recommended to create a subtheme.
 
-### Step 2
-Go to the root of `apigee_kickstart` theme and run the following commands: `npm install`.
+## Creating an Apigee Kickstart Subtheme
 
-### Step 3
-Update `proxy` in **webpack.mix.json**.
+This theme provides a very lightweight starter kit at `src/kits/apigee_custom`. The kit is used by Drush when generating a subtheme (see instructions below), but may also be used as a reference or copied/edited manually to create a subtheme as described in the following secsions.
 
-### Step 4
-Run the following command to compile Sass and watch for changes: `npm run watch`.
+### Using Drush to Generate your Subtheme
 
-## Customizing this theme
-It is recommended to [create a subtheme](https://www.drupal.org/docs/8/theming-drupal-8/creating-a-drupal-8-sub-theme-or-sub-theme-of-sub-theme) in order to [customize this theme](https://www.drupal.org/docs/8/theming).
+Drush can be used to generate a subtheme of `apigee_kickstart` for you.
+
+1. First, ensure you have a working **Drush 9** installation. See [Drush documentation](https://docs.drush.org/en/master/install/) for details.
+
+2. Navigate to the site root in your terminal, substituting `my-portal` with your directory, i.e. `cd ~/Sites/my-portal`.
+
+3. Run the Drush command, substituting `subtheme` with what you'd like your subtheme's machine name to be:
+
+    `drush --include="web/themes/contrib/radix" radix:create "subtheme" --kit=web/profiles/contrib/apigee_devportal_kickstart/themes/custom/apigee_kickstart/src/kits/apigee_custom`
+
+Upon completion of the Drush command, you will have a newly created theme at `web/themes/custom/subtheme`.
+
+### Creating a Subtheme Manually
+
+The starter kit can be copied and manually edited to achieve the same result as what the Drush script does using the following steps:
+
+1. Copy the starter kit into the custom themes directory: `web/themes/custom/subtheme`.
+2. Change all occurrences of `apigee_custom` in file names, including those in `config/` to reflect your theme's machine name.
+3. Change all occurrences of `RADIX_SUBTHEME_MACHINE_NAME` to reflect your theme's machine name.
+4. Open `subtheme.info.yml` and remove the line that reads `hidden: true`.
+
+### Enable your New Subtheme
+
+When your new subtheme is ready, you will need to enable it:
+
+1. Visit `/admin/appearance`
+2. Scroll down to your subtheme.
+3. Click "Install and set as default" link.
+
+### Theming
+
+Add your custom CSS styles in `subtheme/css/subtheme.style.css` and custom scripts in `subtheme/js/subtheme.script.js`.
+
+#### Learn More
+
+- Check out the [Drupal 8 Theming Guide](https://www.drupal.org/docs/8/theming) to learn more about how to work with Drupal 8 themes.
+- Learn how to [Disable Drupal 8 caching during development](https://www.drupal.org/node/2598914).
+
+## Running the Build Script
+
+This theme theme uses [Webpack](https://webpack.js.org) to compile and bundle SASS and JS. **Node.js** and **NPM** are required for using the theme's build script. See NPM's [Downloading and installing Node.js and npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) guide for instructions.
+
+1. Navigate to the root of this theme in your terminal, and install NPM dependencies: `npm install`.
+2. Change the `proxy` variable in `webpack.mix.js`.
+3. Start the build script, which will compile Sass and watch for changes: `npm run watch`.`

--- a/themes/custom/apigee_kickstart/src/kits/apigee_custom/README.md
+++ b/themes/custom/apigee_kickstart/src/kits/apigee_custom/README.md
@@ -1,0 +1,26 @@
+# Apigee Custom
+
+Apigee Custom is a [Radix](https://www.drupal.org/project/radix) kit based on Apigee Kickstart for easy theme customization.
+
+## Usage
+
+Drush can be used to generate a subtheme of `apigee_kickstart` for you.
+
+1. First, ensure you have a working **Drush 9** installation. See [Drush documentation](https://docs.drush.org/en/master/install/) for details.
+
+2. Navigate to the site root in your terminal, substituting `my-portal` with your directory, i.e. `cd ~/Sites/my-portal`.
+
+3. Run the Drush command, substituting `subtheme` with what you'd like your subtheme's machine name to be:
+
+    `drush --include="web/themes/contrib/radix" radix:create "subtheme" --kit=web/profiles/contrib/apigee_devportal_kickstart/themes/custom/apigee_kickstart/src/kits/apigee_custom`
+
+Upon completion of the Drush command, you will have a newly created theme at `web/themes/custom/subtheme`.
+
+## Theming
+
+Add your custom CSS styles in `subtheme/css/subtheme.style.css` and custom scripts in `subtheme/js/subtheme.script.js`.
+
+## Learn More
+
+- Check out the [Drupal 8 Theming Guide](https://www.drupal.org/docs/8/theming) to learn more about how to work with Drupal 8 themes.
+- Learn how to [Disable Drupal 8 caching during development](https://www.drupal.org/node/2598914).

--- a/themes/custom/apigee_kickstart/src/kits/apigee_custom/apigee_custom.customizer.yml
+++ b/themes/custom/apigee_kickstart/src/kits/apigee_custom/apigee_custom.customizer.yml
@@ -1,0 +1,10 @@
+colors:
+  name: Colors
+  variables:
+    --ak-header-color-bg: 'Header: background color'
+    --ak-header-color: 'Header: text color'
+    --ak-footer-color-bg: 'Footer: background color'
+    --ak-footer-color: 'Footer: color'
+    --ak-accent-color: 'Accent color'
+    --ak-accent-color-light: 'Accent color: light'
+    --ak-accent-color-dark: 'Accent color: dark'

--- a/themes/custom/apigee_kickstart/src/kits/apigee_custom/apigee_custom.info.yml
+++ b/themes/custom/apigee_kickstart/src/kits/apigee_custom/apigee_custom.info.yml
@@ -1,0 +1,34 @@
+name: RADIX_SUBTHEME_NAME
+description: A subtheme of Apigee Kickstart.
+screenshot: screenshot.png
+core: 8.x
+type: theme
+base theme: apigee_kickstart
+hidden: true
+
+regions:
+  navbar_branding: 'Navbar Branding'
+  navbar_left:  'Navbar Left'
+  navbar_right: 'Navbar Right'
+  breadcrumbs: Breadcrumbs
+  header: Header
+  content_above: 'Content Above'
+  tasks: Tasks
+  content: Content
+  sidebar_first: 'Sidebar First'
+  sidebar_second: 'Sidebar Second'
+  content_below: 'Content Below'
+  footer: Footer
+  copyright: Copyright
+
+libraries:
+  - radix/style
+  - apigee_kickstart/font.roboto
+  - apigee_kickstart/style
+  - RADIX_SUBTHEME_MACHINE_NAME/style
+
+libraries-override:
+  radix/bootstrap: false
+
+ckeditor_stylesheets:
+  - assets/css/RADIX_SUBTHEME_MACHINE_NAME.style.css

--- a/themes/custom/apigee_kickstart/src/kits/apigee_custom/apigee_custom.libraries.yml
+++ b/themes/custom/apigee_kickstart/src/kits/apigee_custom/apigee_custom.libraries.yml
@@ -1,0 +1,9 @@
+style:
+  css:
+    theme:
+      css/RADIX_SUBTHEME_MACHINE_NAME.style.css: {}
+  js:
+    js/RADIX_SUBTHEME_MACHINE_NAME.script.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupal

--- a/themes/custom/apigee_kickstart/src/kits/apigee_custom/apigee_custom.theme
+++ b/themes/custom/apigee_kickstart/src/kits/apigee_custom/apigee_custom.theme
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Theme and preprocess functions.
+ */

--- a/themes/custom/apigee_kickstart/src/kits/apigee_custom/config/install/apigee_kickstart_customizer.theme.apigee_custom.yml
+++ b/themes/custom/apigee_kickstart/src/kits/apigee_custom/config/install/apigee_kickstart_customizer.theme.apigee_custom.yml
@@ -1,0 +1,8 @@
+values:
+  '--ak-header-color-bg': '#505050'
+  '--ak-header-color': '#ffffff'
+  '--ak-footer-color-bg': '#505050'
+  '--ak-footer-color': '#fcfcfc'
+  '--ak-accent-color': '#2196f3'
+  '--ak-accent-color-light': '#ffffff'
+  '--ak-accent-color-dark': '#0c83e2'

--- a/themes/custom/apigee_kickstart/src/kits/apigee_custom/config/schema/apigee_custom.schema.yml
+++ b/themes/custom/apigee_kickstart/src/kits/apigee_custom/config/schema/apigee_custom.schema.yml
@@ -1,0 +1,5 @@
+# Schema for the configuration files of the RADIX_SUBTHEME_NAME theme.
+
+RADIX_SUBTHEME_MACHINE_NAME.settings:
+  type: theme_settings
+  label: 'RADIX_SUBTHEME_NAME settings'

--- a/themes/custom/apigee_kickstart/src/kits/apigee_custom/css/apigee_custom.style.css
+++ b/themes/custom/apigee_kickstart/src/kits/apigee_custom/css/apigee_custom.style.css
@@ -1,0 +1,31 @@
+/**
+ * CSS variables.
+ *
+ * The apigee_kickstart theme uses CSS Variables for some rules, which are
+ * also available to customize in the UI via Customizer. The color fields are
+ * defined in `THEME.customizer.yml`, and their default values (which should
+ * mirror the values you set below) are defined in
+ * `config/install/apigee_kickstart_customizer.theme.THEME.yml`.
+ *
+ * By default, the variables point to other CSS variable values, which originate
+ * from the Bootstrap build. See the partials linked in the "CSS Variables"
+ * section in apigee_kickstart/src/sass/apigee-kickstart.style.scss for more
+ * details.
+ *
+ * :root {
+ *   --ak-header-color-bg: var(--dark);
+ *   --ak-header-color: var(--white);
+ *   --ak-footer-color-bg: var(--dark);
+ *   --ak-footer-color: var(--white);
+ *   --ak-accent-color: var(--blue);
+ *   --ak-accent-color-light: var(--white);
+ *   --ak-accent-color-dark: var(--blue-dark);
+ * }
+ */
+
+/**
+ * Add custom CSS here.
+ */
+body {
+
+}

--- a/themes/custom/apigee_kickstart/src/kits/apigee_custom/js/apigee_custom.script.js
+++ b/themes/custom/apigee_kickstart/src/kits/apigee_custom/js/apigee_custom.script.js
@@ -1,0 +1,9 @@
+/**
+ * Add custom script here.
+ */
+
+(function () {
+
+  'use strict';
+
+})(jQuery, Drupal);


### PR DESCRIPTION
Fixes #127.

As mentioned in #127, the following issues need to be worked out before this is merged.

- [x] [radix] [Task] [Provide a means to rename other additional configuration files](https://www.drupal.org/project/radix/issues/3081166)
- [x] [radix] [Task] [Drush subtheme generator expects the kit to be located in Radix](https://www.drupal.org/project/radix/issues/3081150)
