### PR TITLE
[#83] Add migrations for Drupal 7 devportal entity types

### DIFF
--- a/modules/custom/apigee_kickstart_migrate/README.md
+++ b/modules/custom/apigee_kickstart_migrate/README.md
@@ -1,0 +1,92 @@
+# Introduction
+The apigee_kickstart_migrate module provides a migration path for Drupal 7 
+Devportal to Drupal 8 Kickstart.
+
+## Migrations
+The module ships with migrations for all entity types that are available out of
+box in Drupal 7 Devportal, including content types, taxonomy terms and comment types.
+
+Note: User accounts are not migrated but are pulled from Apigee Edge during synchronization.
+
+|               | Drupal 7 (Devportal)    | Drupal 8 (Kickstart)    |
+|---------------|-------------------------|-------------------------|
+| Content Types | **Article (article)**   | **Article (article)**   |
+|               | title                   | title                   |
+|               | body                    | body                    |
+|               | field_keywords          | field_tags              |
+|               |                         |                         |
+|               | **Basic page (page)**   | **Basic page (page)**   |
+|               | title                   | title                   |
+|               | body                    | body                    |
+|               |                         |                         |
+|               | **FAQ (faq)**           | **FAQ (faq)**           |
+|               | title                   | title                   |
+|               | body                    | field_answer            |
+|               |                         |                         |
+|               | **Forum topic (forum)** | **Forum topic (forum)** |
+|               | title                   | title                   |
+|               | body                    | body                    |
+|               | taxonomy_forums         | taxonomy_forums         |
+|               |                         |                         |
+| Comment Types | **Comment (comment)**   | **Comment (comment)**   |
+|               | author                  | author                  |
+|               | subject                 | subject                 |
+|               | comment_body            | comment_body            |
+|               |                         |                         |
+| Taxonomy      | **Forums (forums)**     | **Forum (forums)**      |
+|               | name                    | name                    |
+|               |                         |                         |
+|               | **Tags (tags)**         | **Tags (tags)**         |
+|               | name                    | name                    |
+
+## Requirements
+1. A valid connection to Apigee Edge. See the [documentation](https://www.drupal.org/docs/8/modules/apigee-edge/configure-the-connection-to-apigee-edge) 
+on how to configure an Apigee Edge Connection.
+2. All developer accounts on Edge synchronized with your Drupal site. See the [documentation](https://www.drupal.org/docs/8/modules/apigee-edge/synchronize-developers-with-apigee-edge) on how to synchronize 
+developer accounts.
+
+## Installation
+1. Configure the source (Drupal 7 devportal) database connection in your `settings.php` file.
+
+```
+$databases['migrate']['default'] = array (
+  'database' => 'D7_DATABASE_NAME',
+  'username' => 'USERNAME',
+  'password' => 'PASSWORD',
+  'prefix' => '',
+  'host' => 'localhost',
+  'port' => '',
+  'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
+  'driver' => 'mysql',
+);
+```
+2. Enable the `apigee_kickstart_migrate` module: `drush en apigee_kickstart_migrate -y`
+
+You should now be ready to run the migrations.
+
+## Running migrations
+#### To see a list of migrations, run the following command: 
+
+`$ drush ms --group=devportal`
+
+#### To run a migration:
+
+`$ drush mim devportal_article --execute-dependencies` 
+
+#### To revert a migration:
+
+`$ drush mr devportal_article`
+
+#### To run all devportal migrations:
+
+`$ drush mim --group=devportal`
+
+## Custom migrations
+
+In most cases, the entity types on your Drupal 7 Devportal have been customized 
+with additional fields. Since this is different for every Devportal, the 
+default migrations do not handle these fields. You will need to write your 
+own migration.
+
+The **apigee_kickstart_migrate_example** module provides examples on how you 
+can extend the default migrations to add your own custom fields. 

--- a/modules/custom/apigee_kickstart_migrate/apigee_kickstart_migrate.info.yml
+++ b/modules/custom/apigee_kickstart_migrate/apigee_kickstart_migrate.info.yml
@@ -1,0 +1,10 @@
+name: Apigee Kickstart Migrate
+description: "Provides a migration path from Drupal 7 Devportal to Drupal 8 Kickstart."
+type: module
+core: 8.x
+package: Apigee Kickstart
+dependencies:
+  - drupal:migrate
+  - drupal:migrate_drupal
+  - migrate_plus:migrate_plus
+  - migrate_tools:migrate_tools

--- a/modules/custom/apigee_kickstart_migrate/apigee_kickstart_migrate_example/apigee_kickstart_migrate_example.info.yml
+++ b/modules/custom/apigee_kickstart_migrate/apigee_kickstart_migrate_example/apigee_kickstart_migrate_example.info.yml
@@ -1,0 +1,11 @@
+name: Apigee Kickstart Migrate Example
+description: "Examples of how to extend Drupal 7 Devportal migrations."
+type: module
+core: 8.x
+package: Examples
+dependencies:
+  - drupal:migrate
+  - drupal:migrate_drupal
+  - migrate_plus:migrate_plus
+  - migrate_tools:migrate_tools
+  - apigee_kickstart_migrate:apigee_kickstart_migrate

--- a/modules/custom/apigee_kickstart_migrate/apigee_kickstart_migrate_example/config/install/migrate_plus.migration.example_article.yml
+++ b/modules/custom/apigee_kickstart_migrate/apigee_kickstart_migrate_example/config/install/migrate_plus.migration.example_article.yml
@@ -1,0 +1,38 @@
+id: example_article
+status: true
+label: Article (Example)
+migration_group: devportal_example
+source:
+  plugin: devportal_node
+  node_type: article
+destination:
+  plugin: 'entity:node'
+  default_bundle: article
+process:
+  langcode:
+    plugin: default_value
+    source: language
+    default_value: und
+  title: title
+  uid:
+    plugin: entity_lookup
+    source: user_mail
+    value_key: mail
+    entity_type: user
+  status: status
+  created: created
+  changed: changed
+  promote: promote
+  sticky: sticky
+  revision_uid: revision_uid
+  revision_log: log
+  revision_timestamp: timestamp
+  body:
+    plugin: sub_process
+    source: body
+    process:
+      value: value
+      format:
+        plugin: default_value
+        default_value: full_html
+  field_foo: field_foo

--- a/modules/custom/apigee_kickstart_migrate/apigee_kickstart_migrate_example/config/install/migrate_plus.migration_group.devportal_example.yml
+++ b/modules/custom/apigee_kickstart_migrate/apigee_kickstart_migrate_example/config/install/migrate_plus.migration_group.devportal_example.yml
@@ -1,0 +1,4 @@
+id: devportal_example
+label: Devportal Example
+description: Examples migrations from Drupal 7 Devportal.
+source_type: Drupal 7

--- a/modules/custom/apigee_kickstart_migrate/composer.json
+++ b/modules/custom/apigee_kickstart_migrate/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "drupal/apigee_kickstart_migrate",
+    "license": "GPL-2.0",
+    "type": "drupal-module",
+    "description": "Provides a migration path from Drupal 7 Devportal to Drupal 8 Kickstart.",
+    "require": {
+        "php": ">=7.1",
+        "drupal/migrate_plus": "^4.2",
+        "drupal/migrate_tools": "^4.3"
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/modules/custom/apigee_kickstart_migrate/config/install/migrate_plus.migration.devportal_article.yml
+++ b/modules/custom/apigee_kickstart_migrate/config/install/migrate_plus.migration.devportal_article.yml
@@ -1,0 +1,46 @@
+id: devportal_article
+status: true
+label: Article (Content type)
+migration_group: devportal
+source:
+  plugin: devportal_node
+  node_type: article
+destination:
+  plugin: 'entity:node'
+  default_bundle: article
+process:
+  langcode:
+    plugin: default_value
+    source: language
+    default_value: und
+  title: title
+  uid:
+    plugin: entity_lookup
+    source: user_mail
+    value_key: mail
+    entity_type: user
+  status: status
+  created: created
+  changed: changed
+  promote: promote
+  sticky: sticky
+  revision_uid: revision_uid
+  revision_log: log
+  revision_timestamp: timestamp
+  body:
+    plugin: sub_process
+    source: body
+    process:
+      value: value
+      format:
+        plugin: default_value
+        default_value: full_html
+  field_tags:
+    -
+      plugin: migration_lookup
+      source: field_keywords
+      migration:
+        - devportal_taxonomy_blog
+migration_dependencies:
+  required:
+    - devportal_taxonomy_blog

--- a/modules/custom/apigee_kickstart_migrate/config/install/migrate_plus.migration.devportal_comment.yml
+++ b/modules/custom/apigee_kickstart_migrate/config/install/migrate_plus.migration.devportal_comment.yml
@@ -1,0 +1,54 @@
+id: devportal_comment
+status: true
+migration_group: devportal
+label: Comment (Comment type)
+source:
+  plugin: d7_comment
+  constants:
+    entity_type: node
+process:
+  cid: cid
+  pid:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: pid
+  entity_id:
+    -
+      plugin: migration_lookup
+      migration:
+        - devportal_article
+        - devportal_forum
+        - devportal_page
+      source: nid
+    -
+      plugin: skip_on_empty
+      method: row
+  entity_type: constants/entity_type
+  comment_type:
+    -
+      plugin: default_value
+      default_value: 'comment'
+    -
+      plugin: skip_on_empty
+      method: row
+  langcode: language
+  field_name: '@comment_type'
+  subject: subject
+  uid: uid
+  name: name
+  mail: mail
+  homepage: homepage
+  hostname: hostname
+  created: created
+  changed: changed
+  status: status
+  thread: thread
+  comment_body: comment_body
+destination:
+  plugin: 'entity:comment'
+migration_dependencies:
+  required:
+    - devportal_article
+    - devportal_forum
+    - devportal_page

--- a/modules/custom/apigee_kickstart_migrate/config/install/migrate_plus.migration.devportal_comment.yml
+++ b/modules/custom/apigee_kickstart_migrate/config/install/migrate_plus.migration.devportal_comment.yml
@@ -3,7 +3,7 @@ status: true
 migration_group: devportal
 label: Comment (Comment type)
 source:
-  plugin: d7_comment
+  plugin: devportal_comment
   constants:
     entity_type: node
 process:
@@ -25,19 +25,17 @@ process:
       plugin: skip_on_empty
       method: row
   entity_type: constants/entity_type
-  comment_type:
-    -
-      plugin: default_value
-      default_value: 'comment'
-    -
-      plugin: skip_on_empty
-      method: row
+  comment_type: comment_type_name
   langcode: language
   field_name: '@comment_type'
   subject: subject
-  uid: uid
+  uid:
+    plugin: entity_lookup
+    source: user_mail
+    value_key: mail
+    entity_type: user
   name: name
-  mail: mail
+  mail: user_mail
   homepage: homepage
   hostname: hostname
   created: created

--- a/modules/custom/apigee_kickstart_migrate/config/install/migrate_plus.migration.devportal_comment.yml
+++ b/modules/custom/apigee_kickstart_migrate/config/install/migrate_plus.migration.devportal_comment.yml
@@ -13,6 +13,9 @@ process:
       plugin: skip_on_empty
       method: process
       source: pid
+    -
+      plugin: migration_lookup
+      migration: devportal_comment
   entity_id:
     -
       plugin: migration_lookup

--- a/modules/custom/apigee_kickstart_migrate/config/install/migrate_plus.migration.devportal_faq.yml
+++ b/modules/custom/apigee_kickstart_migrate/config/install/migrate_plus.migration.devportal_faq.yml
@@ -1,0 +1,37 @@
+id: devportal_faq
+status: true
+label: FAQ (Content type)
+migration_group: devportal
+source:
+  plugin: devportal_node
+  node_type: faq
+destination:
+  plugin: 'entity:node'
+  default_bundle: faq
+process:
+  langcode:
+    plugin: default_value
+    source: language
+    default_value: und
+  title: title
+  uid:
+    plugin: entity_lookup
+    source: user_mail
+    value_key: mail
+    entity_type: user
+  status: status
+  created: created
+  changed: changed
+  promote: promote
+  sticky: sticky
+  revision_uid: revision_uid
+  revision_log: log
+  revision_timestamp: timestamp
+  field_answer:
+    plugin: sub_process
+    source: body
+    process:
+      value: value
+      format:
+        plugin: default_value
+        default_value: full_html

--- a/modules/custom/apigee_kickstart_migrate/config/install/migrate_plus.migration.devportal_forum.yml
+++ b/modules/custom/apigee_kickstart_migrate/config/install/migrate_plus.migration.devportal_forum.yml
@@ -1,0 +1,46 @@
+id: devportal_forum
+status: true
+label: Forum (Content type)
+migration_group: devportal
+source:
+  plugin: devportal_node
+  node_type: forum
+destination:
+  plugin: 'entity:node'
+  default_bundle: forum
+process:
+  langcode:
+    plugin: default_value
+    source: language
+    default_value: und
+  title: title
+  uid:
+    plugin: entity_lookup
+    source: user_mail
+    value_key: mail
+    entity_type: user
+  status: status
+  created: created
+  changed: changed
+  promote: promote
+  sticky: sticky
+  revision_uid: revision_uid
+  revision_log: log
+  revision_timestamp: timestamp
+  body:
+    plugin: sub_process
+    source: body
+    process:
+      value: value
+      format:
+        plugin: default_value
+        default_value: full_html
+  taxonomy_forums:
+    -
+      plugin: migration_lookup
+      source: taxonomy_forums
+      migration:
+        - devportal_taxonomy_forums
+migration_dependencies:
+  required:
+    - devportal_taxonomy_forums

--- a/modules/custom/apigee_kickstart_migrate/config/install/migrate_plus.migration.devportal_page.yml
+++ b/modules/custom/apigee_kickstart_migrate/config/install/migrate_plus.migration.devportal_page.yml
@@ -1,0 +1,37 @@
+id: devportal_page
+status: true
+label: Basic page (Content type)
+migration_group: devportal
+source:
+  plugin: devportal_node
+  node_type: page
+destination:
+  plugin: 'entity:node'
+  default_bundle: page
+process:
+  langcode:
+    plugin: default_value
+    source: language
+    default_value: und
+  title: title
+  uid:
+    plugin: entity_lookup
+    source: user_mail
+    value_key: mail
+    entity_type: user
+  status: status
+  created: created
+  changed: changed
+  promote: promote
+  sticky: sticky
+  revision_uid: revision_uid
+  revision_log: log
+  revision_timestamp: timestamp
+  body:
+    plugin: sub_process
+    source: body
+    process:
+      value: value
+      format:
+        plugin: default_value
+        default_value: full_html

--- a/modules/custom/apigee_kickstart_migrate/config/install/migrate_plus.migration.devportal_taxonomy_blog.yml
+++ b/modules/custom/apigee_kickstart_migrate/config/install/migrate_plus.migration.devportal_taxonomy_blog.yml
@@ -1,0 +1,33 @@
+status: true
+id: devportal_taxonomy_blog
+migration_group: devportal
+label: Blog (Taxonomy)
+source:
+  plugin: d7_taxonomy_term
+  bundle: blog
+process:
+  tid: tid
+  vid:
+    -
+      plugin: default_value
+      default_value: tags
+  name: name
+  description/value: description
+  description/format: format
+  weight: weight
+  parent_id:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: parent
+  parent:
+    -
+      plugin: default_value
+      default_value: 0
+      source: '@parent_id'
+  forum_container: is_container
+  changed: timestamp
+  langcode: language
+destination:
+  plugin: 'entity:taxonomy_term'
+  default_bundle: tags

--- a/modules/custom/apigee_kickstart_migrate/config/install/migrate_plus.migration.devportal_taxonomy_forums.yml
+++ b/modules/custom/apigee_kickstart_migrate/config/install/migrate_plus.migration.devportal_taxonomy_forums.yml
@@ -1,0 +1,33 @@
+status: true
+id: devportal_taxonomy_forums
+migration_group: devportal
+label: Forums (Taxonomy)
+source:
+  plugin: d7_taxonomy_term
+  bundle: forums
+process:
+  tid: tid
+  vid:
+    -
+      plugin: default_value
+      default_value: forums
+  name: name
+  description/value: description
+  description/format: format
+  weight: weight
+  parent_id:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: parent
+  parent:
+    -
+      plugin: default_value
+      default_value: 0
+      source: '@parent_id'
+  forum_container: is_container
+  changed: timestamp
+  langcode: language
+destination:
+  plugin: 'entity:taxonomy_term'
+  default_bundle: forums

--- a/modules/custom/apigee_kickstart_migrate/config/install/migrate_plus.migration.devportal_taxonomy_tags.yml
+++ b/modules/custom/apigee_kickstart_migrate/config/install/migrate_plus.migration.devportal_taxonomy_tags.yml
@@ -1,0 +1,33 @@
+status: true
+id: devportal_taxonomy_tags
+migration_group: devportal
+label: Tags (Taxonomy)
+source:
+  plugin: d7_taxonomy_term
+  bundle: tags
+process:
+  tid: tid
+  vid:
+    -
+      plugin: default_value
+      default_value: tags
+  name: name
+  description/value: description
+  description/format: format
+  weight: weight
+  parent_id:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: parent
+  parent:
+    -
+      plugin: default_value
+      default_value: 0
+      source: '@parent_id'
+  forum_container: is_container
+  changed: timestamp
+  langcode: language
+destination:
+  plugin: 'entity:taxonomy_term'
+  default_bundle: tags

--- a/modules/custom/apigee_kickstart_migrate/config/install/migrate_plus.migration_group.devportal.yml
+++ b/modules/custom/apigee_kickstart_migrate/config/install/migrate_plus.migration_group.devportal.yml
@@ -1,0 +1,4 @@
+id: devportal
+label: Devportal
+description: Migrations from Drupal 7 Devportal.
+source_type: Drupal 7

--- a/modules/custom/apigee_kickstart_migrate/src/Plugin/migrate/source/DevportalComment.php
+++ b/modules/custom/apigee_kickstart_migrate/src/Plugin/migrate/source/DevportalComment.php
@@ -1,5 +1,23 @@
 <?php
 
+/**
+ * Copyright 2019 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
 namespace Drupal\apigee_kickstart_migrate\Plugin\migrate\source;
 
 use Drupal\comment\Plugin\migrate\source\d7\Comment;

--- a/modules/custom/apigee_kickstart_migrate/src/Plugin/migrate/source/DevportalComment.php
+++ b/modules/custom/apigee_kickstart_migrate/src/Plugin/migrate/source/DevportalComment.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drupal\apigee_kickstart_migrate\Plugin\migrate\source;
+
+use Drupal\comment\Plugin\migrate\source\d7\Comment;
+use Drupal\migrate\Row;
+
+/**
+ * @MigrateSource(
+ *   id = "devportal_comment"
+ * )
+ */
+class DevportalComment extends Comment {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    $query = parent::query();
+    $query->innerJoin('users', 'u', 'c.uid = u.uid');
+    $query->addField('u', 'mail', 'user_mail');
+    return $query;
+  }
+
+  public function prepareRow(Row $row) {
+    $comment_type = $row->getSourceProperty('node_type') === 'forum' ? 'comment_forum' : 'comment';
+    $row->setSourceProperty('comment_type_name', $comment_type);
+    return parent::prepareRow($row);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fields() {
+    $fields =  parent::fields();
+    $fields['comment_type_name'] = $this->t('The comment type.');
+    $fields['user_mail'] = $this->t('The email of the user.');
+    return $fields;
+  }
+
+}

--- a/modules/custom/apigee_kickstart_migrate/src/Plugin/migrate/source/DevportalComment.php
+++ b/modules/custom/apigee_kickstart_migrate/src/Plugin/migrate/source/DevportalComment.php
@@ -24,6 +24,8 @@ use Drupal\comment\Plugin\migrate\source\d7\Comment;
 use Drupal\migrate\Row;
 
 /**
+ * Migrate source for Drupal 7 comment with custom fields.
+ *
  * @MigrateSource(
  *   id = "devportal_comment"
  * )
@@ -40,6 +42,9 @@ class DevportalComment extends Comment {
     return $query;
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function prepareRow(Row $row) {
     $comment_type = $row->getSourceProperty('node_type') === 'forum' ? 'comment_forum' : 'comment';
     $row->setSourceProperty('comment_type_name', $comment_type);
@@ -50,7 +55,7 @@ class DevportalComment extends Comment {
    * {@inheritdoc}
    */
   public function fields() {
-    $fields =  parent::fields();
+    $fields = parent::fields();
     $fields['comment_type_name'] = $this->t('The comment type.');
     $fields['user_mail'] = $this->t('The email of the user.');
     return $fields;

--- a/modules/custom/apigee_kickstart_migrate/src/Plugin/migrate/source/DevportalNode.php
+++ b/modules/custom/apigee_kickstart_migrate/src/Plugin/migrate/source/DevportalNode.php
@@ -1,5 +1,23 @@
 <?php
 
+/**
+ * Copyright 2019 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
 namespace Drupal\apigee_kickstart_migrate\Plugin\migrate\source;
 
 use Drupal\node\Plugin\migrate\source\d7\Node;

--- a/modules/custom/apigee_kickstart_migrate/src/Plugin/migrate/source/DevportalNode.php
+++ b/modules/custom/apigee_kickstart_migrate/src/Plugin/migrate/source/DevportalNode.php
@@ -23,6 +23,8 @@ namespace Drupal\apigee_kickstart_migrate\Plugin\migrate\source;
 use Drupal\node\Plugin\migrate\source\d7\Node;
 
 /**
+ * Migrate source for Drupal 7 node with custom fields.
+ *
  * @MigrateSource(
  *   id = "devportal_node"
  * )
@@ -43,7 +45,7 @@ class DevportalNode extends Node {
    * {@inheritdoc}
    */
   public function fields() {
-    $fields =  parent::fields();
+    $fields = parent::fields();
     $fields['user_mail'] = $this->t('The email of the user');
     return $fields;
   }

--- a/modules/custom/apigee_kickstart_migrate/src/Plugin/migrate/source/DevportalNode.php
+++ b/modules/custom/apigee_kickstart_migrate/src/Plugin/migrate/source/DevportalNode.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\apigee_kickstart_migrate\Plugin\migrate\source;
+
+use Drupal\node\Plugin\migrate\source\d7\Node;
+
+/**
+ * @MigrateSource(
+ *   id = "devportal_node"
+ * )
+ */
+class DevportalNode extends Node {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    $query = parent::query();
+    $query->innerJoin('users', 'u', 'n.uid = u.uid');
+    $query->addField('u', 'mail', 'user_mail');
+    return $query;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fields() {
+    $fields =  parent::fields();
+    $fields['user_mail'] = $this->t('The email of the user');
+    return $fields;
+  }
+
+}


### PR DESCRIPTION
Fixes #83 

This PR adds the `apigee_kickstart_migrate` module with migrations for all entity types that ship with the Drupal 7 devportal.

## Migrations

The following tables list the fields for all entity types that ship with the Drupal 7 Devportal and their direct mapping for Drupal 8 Kickstart. The apigee_kickstart_migrate module will include migrations for all entity types listed below.


  | Drupal 7 (Devportal) | Drupal 8 (Kickstart)
-- | -- | --
Content Types | **Article (article)** | **Article (article)**
  | title | title
  | body | body
  | field_keywords | field_tags
  | field_content_tag | field_tags
  |   |  
  | **Basic page (page)** | **Basic page (page)**
  | title | title
  | body | body
  |   |  
  | **FAQ (faq)** | **FAQ (faq)**
  | title | title
  | body | field_answer
  | field_detailed_question | -
  |   |  
  | **Forum topic (forum)** | **Forum topic (forum)**
  | title | title
  | body | body
  | taxonomy_forums | taxonomy_forums
  |   |  
Comment Types | **Comment (comment)** | **Comment (comment)**
  | author | author
  | subject | subject
  | comment_body | comment_body
  |   |  
Taxonomy | **Forums (forums)** | **Forum (forums)**
  | name | name
  |   |  
  | **Tags (tags)** | **Tags (tags)**
  | name | name

## Installation

1. Install the required migration modules: `composer require drupal/migrate_plus:^4.2 drupal/migrate_tools:^4.3`
2. Configure the source (d7) database connection in your `settings.php` or `settings.local.php` file.

```
$databases['migrate']['default'] = array (
  'database' => 'D7_DATABASE_NAME',
  'username' => 'USERNAME',
  'password' => 'PASSWORD',
  'prefix' => '',
  'host' => 'localhost',
  'port' => '',
  'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
  'driver' => 'mysql',
);
```
3. Enable the `apigee_kickstart_migrate` module: `drush en apigee_kickstart_migrate -y`
4. [Configure an Apigee Edge connection](https://www.drupal.org/docs/8/modules/apigee-edge/configure-the-connection-to-apigee-edge) and [run the developer sync](https://www.drupal.org/docs/8/modules/apigee-edge/synchronize-developers-with-apigee-edge). This is required to map user id fields.
5. You should now be ready to run the migrations.

## Running migrations

#### To see a list of migrations, run the following command: 

`$ drush ms --group=devportal`

#### To run a migration:

`$ drush mim devportal_article --execute-dependencies` 

#### To revert a migration:

`$ drush mr devportal_article`

#### To run all devportal migrations:

`$ drush mim --group=devportal`

## Custom migrations

In most cases, the entity types on your Drupal 7 Devportal have been customized 
with additional fields. Since this is different for every Devportal, the 
default migrations do not handle these fields. You will need to write your 
own migration.

The **apigee_kickstart_migrate_example** module provides examples on how you 
can extend the default migrations to add your own custom fields. 


