### PR TITLE
Documentation updates/fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@
 
 This project is a [Drupal installation profile](https://www.drupal.org/docs/8/distributions) which needs to be added to Drupal core and installed using [Composer](https://getcomposer.org). The [installation instructions](https://www.drupal.org/docs/8/modules/apigee-developer-portal-kickstart/get-started-with-kickstart)  use the [Apigee Developer Portal Kickstart Composer project](https://github.com/apigee/devportal-kickstart-project-composer) to install Drupal core and this installation profile to create a site.
 
-## Profile status
+## Project status
 
 The core functionality of this profile is in active development. The features and functionality will evolve as the project grows. We encourage you to download and evaluate the profile, and to use our [GitHub issue queue](https://github.com/apigee/apigee-devportal-kickstart-drupal/issues) to give feedback, ask questions, or log issues.
 
+## Customizing the look and feel
+Information on how to customize the look and feel of the site can be found in the subtheme's README at: `themes/custom/apigee_kickstart/README.md`.
+
 ## Documentation
 
-The documentation guide for the Apigee Developer Portal Kickstart profile is located at: https://www.drupal.org/docs/8/modules/apigee-developer-portal-kickstart
+Full documentation is up on the [Drupal.org Apigee Developer Portal Kickstart profile documentation page](https://www.drupal.org/docs/8/modules/apigee-developer-portal-kickstart).
 
 ## Issues, questions and feedback
 

--- a/themes/custom/apigee_kickstart/README.md
+++ b/themes/custom/apigee_kickstart/README.md
@@ -3,27 +3,27 @@
 The Apigee Kickstart theme uses the [Radix](https://drupal.org/project/radix) as its base theme. There are two different ways you can customize the look and feel of this theme:
 
 1. **Customize the color scheme in the user interface**: It's possible to customize the color scheme used in this theme without writing any code. When logged in as a privileged user with `apigee_kickstart` enabled as the default theme, you'll see a **Customize** link in the Toolbar on the front end of the site. Clicking the **Customize** link opens the Settings Tray, which contains 7 color fields, which you can edit using a color wheel. Use these fields to customize the colors for the site header, footer, and accents, such as buttons and icons.
-2. **Customizing in code by creating a subtheme**: If you'd like to add or make adjustments to templates, CSS or JavaScript, it is recommended to create a subtheme.
+2. **Customizing in code by creating a sub-theme**: If you'd like to add or make adjustments to templates, CSS or JavaScript, it is recommended to create a sub-theme.
 
-## Creating an Apigee Kickstart Subtheme
+## Creating an Apigee Kickstart Sub-theme
 
-This theme provides a very lightweight starter kit at `src/kits/apigee_custom`. The kit is used by Drush when generating a subtheme (see instructions below), but may also be used as a reference or copied/edited manually to create a subtheme as described in the following secsions.
+This theme provides a very lightweight starter kit at `src/kits/apigee_custom`. The kit is used by Drush when generating a subtheme (see instructions below), but may also be used as a reference or copied/edited manually to create a subtheme as described in the following sections.
 
-### Using Drush to Generate your Subtheme
+### Using Drush to Generate your Sub-theme
 
-Drush can be used to generate a subtheme of `apigee_kickstart` for you.
+Drush can be used to generate a sub-theme of `apigee_kickstart` for you.
 
 1. First, ensure you have a working **Drush 9** installation. See [Drush documentation](https://docs.drush.org/en/master/install/) for details.
 
 2. Navigate to the site root in your terminal, substituting `my-portal` with your directory, i.e. `cd ~/Sites/my-portal`.
 
-3. Run the Drush command, substituting `subtheme` with what you'd like your subtheme's machine name to be:
+3. Run the Drush command, substituting `subtheme` with what you'd like your sub-theme's machine name to be:
 
     `drush --include="web/themes/contrib/radix" radix:create "subtheme" --kit=apigee_custom`
 
 Upon completion of the Drush command, you will have a newly created theme at `web/themes/custom/subtheme`.
 
-### Creating a Subtheme Manually
+### Creating a Sub-theme Manually
 
 The starter kit can be copied and manually edited to achieve the same result as what the Drush script does using the following steps:
 
@@ -32,12 +32,12 @@ The starter kit can be copied and manually edited to achieve the same result as 
 3. Change all occurrences of `RADIX_SUBTHEME_MACHINE_NAME` to reflect your theme's machine name.
 4. Open `subtheme.info.yml` and remove the line that reads `hidden: true`.
 
-### Enable your New Subtheme
+### Enable your New Sub-theme
 
-When your new subtheme is ready, you will need to enable it:
+When your new sub-theme is ready, you will need to enable it:
 
 1. Visit `/admin/appearance`
-2. Scroll down to your subtheme.
+2. Scroll down to your sub-theme.
 3. Click "Install and set as default" link.
 
 ### Theming

--- a/themes/custom/apigee_kickstart/src/kits/apigee_custom/README.md
+++ b/themes/custom/apigee_kickstart/src/kits/apigee_custom/README.md
@@ -4,13 +4,13 @@ Apigee Custom is a [Radix](https://www.drupal.org/project/radix) kit based on Ap
 
 ## Usage
 
-Drush can be used to generate a subtheme of `apigee_kickstart` for you.
+Drush can be used to generate a sub-theme of `apigee_kickstart` for you.
 
 1. First, ensure you have a working **Drush 9** installation. See [Drush documentation](https://docs.drush.org/en/master/install/) for details.
 
 2. Navigate to the site root in your terminal, substituting `my-portal` with your directory, i.e. `cd ~/Sites/my-portal`.
 
-3. Run the Drush command, substituting `subtheme` with what you'd like your subtheme's machine name to be:
+3. Run the Drush command, substituting `subtheme` with what you'd like your sub-theme's machine name to be:
 
     `drush --include="web/themes/contrib/radix" radix:create "subtheme" --kit=web/profiles/contrib/apigee_devportal_kickstart/themes/custom/apigee_kickstart/src/kits/apigee_custom`
 

--- a/themes/custom/apigee_kickstart/src/kits/apigee_custom/apigee_custom.info.yml
+++ b/themes/custom/apigee_kickstart/src/kits/apigee_custom/apigee_custom.info.yml
@@ -1,5 +1,5 @@
 name: RADIX_SUBTHEME_NAME
-description: A subtheme of Apigee Kickstart.
+description: A sub-theme of Apigee Kickstart.
 screenshot: screenshot.png
 core: 8.x
 type: theme


### PR DESCRIPTION
* Spelling fix
* Changed “subtheme” to “sub-theme” to match [Drupal.org spelling](https://www.drupal.org/docs/8/theming-drupal-8/creating-a-drupal-8-sub-theme-or-sub-theme-of-sub-theme)
* Added info in the main README.md to point to the sub-theme documentation