### PR TITLE
[#270] Show the username on the user profile page

### DIFF
--- a/config/install/email_registration.settings.yml
+++ b/config/install/email_registration.settings.yml
@@ -1,0 +1,1 @@
+login_with_username: TRUE

--- a/modules/custom/apigee_kickstart_enhancement/apigee_kickstart_enhancement.module
+++ b/modules/custom/apigee_kickstart_enhancement/apigee_kickstart_enhancement.module
@@ -194,7 +194,7 @@ function _apigee_kickstart_user_extra_fields() {
     'username' => [
       'label' => t('Username'),
       'value_callback' => function (UserInterface $user) {
-        return $user->getDisplayName();
+        return $user->getAccountName();
       },
     ],
     'email' => [

--- a/modules/custom/apigee_kickstart_enhancement/apigee_kickstart_enhancement.module
+++ b/modules/custom/apigee_kickstart_enhancement/apigee_kickstart_enhancement.module
@@ -188,19 +188,13 @@ function _apigee_kickstart_user_extra_fields() {
     'display_name' => [
       'label' => t('Name'),
       'value_callback' => function (UserInterface $user) {
-        $first_name_last_name = trim($user->get('first_name')->value) . ' ' . trim($user->get('last_name')->value);
-        // If both fields were empty this string still could be empty.
-        $first_name_last_name = trim($first_name_last_name);
-        if (!empty($first_name_last_name)) {
-          return $first_name_last_name;
-        }
         return $user->label();
       },
     ],
     'username' => [
       'label' => t('Username'),
       'value_callback' => function (UserInterface $user) {
-        return $user->getDisplayName();
+        return $user->getAccountName();
       },
     ],
     'email' => [

--- a/modules/custom/apigee_kickstart_enhancement/apigee_kickstart_enhancement.module
+++ b/modules/custom/apigee_kickstart_enhancement/apigee_kickstart_enhancement.module
@@ -188,7 +188,14 @@ function _apigee_kickstart_user_extra_fields() {
     'display_name' => [
       'label' => t('Name'),
       'value_callback' => function (UserInterface $user) {
-        return $user->label();
+          $first_name_last_name = trim($user->get('first_name')->value) . ' ' . trim($user->get('last_name')->value);
+          // If both fields were empty this string still could be empty.
+          $first_name_last_name = trim($first_name_last_name);
+          if (!empty($first_name_last_name)) {
+            return $first_name_last_name;
+          } else {
+            return $user->label();
+          }
       },
     ],
     'username' => [

--- a/modules/custom/apigee_kickstart_enhancement/apigee_kickstart_enhancement.module
+++ b/modules/custom/apigee_kickstart_enhancement/apigee_kickstart_enhancement.module
@@ -188,13 +188,19 @@ function _apigee_kickstart_user_extra_fields() {
     'display_name' => [
       'label' => t('Name'),
       'value_callback' => function (UserInterface $user) {
+        $first_name_last_name = trim($user->get('first_name')->value) . ' ' . trim($user->get('last_name')->value);
+        // If both fields were empty this string still could be empty.
+        $first_name_last_name = trim($first_name_last_name);
+        if (!empty($first_name_last_name)) {
+          return $first_name_last_name;
+        }
         return $user->label();
       },
     ],
     'username' => [
       'label' => t('Username'),
       'value_callback' => function (UserInterface $user) {
-        return $user->getAccountName();
+        return $user->getDisplayName();
       },
     ],
     'email' => [


### PR DESCRIPTION
Fixes #270 

This displays the username on the user profile page, enables the username field on the user forms and allows login using the email or the username.

<img width="570" alt="username-on-profile" src="https://user-images.githubusercontent.com/124599/66479110-d9bfa200-eaac-11e9-950e-0ffdbbf356fd.png">

<img width="621" alt="username-field" src="https://user-images.githubusercontent.com/124599/66479122-e17f4680-eaac-11e9-93d9-0e32b5ad96d8.png">

<img width="658" alt="login-username-email" src="https://user-images.githubusercontent.com/124599/66479138-eba14500-eaac-11e9-8816-d17e6962efde.png">
