### PR TITLE
[#276] Replace the forum link with an editable one

### DIFF
--- a/apigee_devportal_kickstart.install
+++ b/apigee_devportal_kickstart.install
@@ -23,6 +23,7 @@ use Drupal\apigee_devportal_kickstart\Installer\Form\ApigeeEdgeConfigurationForm
 use Drupal\apigee_devportal_kickstart\Installer\Form\ApigeeMonetizationConfigurationForm;
 use Drupal\apigee_devportal_kickstart\Installer\Form\DemoInstallForm;
 use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\menu_link_content\Entity\MenuLinkContent;
 
 /**
  * @file
@@ -251,4 +252,28 @@ function apigee_devportal_kickstart_install() {
       }
     }
   }
+
+  // Create a forum link.
+  // This cannot be added as config since uninstalling forum.module will result
+  // in a RouteNotFoundException.
+  // See https://github.com/apigee/apigee-devportal-kickstart-drupal/issues/276.
+  MenuLinkContent::create([
+    'title' => 'Forum',
+    'menu_name' => 'main',
+    'link' => ['uri' => 'internal:/forum'],
+    'weight' => 3,
+  ])->save();
+}
+
+/**
+ * Replace 'Forum' menu link with one that can be edited.
+ */
+function apigee_devportal_kickstart_update_8001(&$sandbox) {
+  // Replaced apigee_devportal_kickstart.links.menu.yml with the following.
+  MenuLinkContent::create([
+    'title' => 'Forum',
+    'menu_name' => 'main',
+    'link' => ['uri' => 'internal:/forum'],
+    'weight' => 3,
+  ])->save();
 }

--- a/apigee_devportal_kickstart.links.menu.yml
+++ b/apigee_devportal_kickstart.links.menu.yml
@@ -1,5 +1,0 @@
-apigee_devportal_kickstart.forum:
-  title: 'Forum'
-  route_name: 'forum.index'
-  menu_name: main
-  weight: 3


### PR DESCRIPTION
Fixes #276 

This PR replaces the Forum link shipped as `apigee_devportal_kickstart.links.menu.yml` with one that can be edited / deleted.

This mitigates the fatal `RouteNotFoundException` on uninstalling forum.module.

After uninstalling the forum module, this link can be safely deleted.