### PR TITLE
Do not let Apigee API Catalog upgrade to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "cweagans/composer-patches": "^1.6.5",
     "drupal/admin_toolbar": "^2.0",
     "drupal/adminimal_admin_toolbar": "^1.9",
-    "drupal/apigee_api_catalog": ">=1.0-beta2",
+    "drupal/apigee_api_catalog": "^1.0",
     "drupal/apigee_edge": "^1.0",
     "drupal/better_exposed_filters": "^3.0@alpha",
     "drupal/default_content": "^1.0@alpha",


### PR DESCRIPTION
Fixes #366. Kickstart should not upgrade to Apigee API Catalog 2.0 until changes are made to Kickstart.