### PR TITLE
[#363] Require apigee_api_catalog ^2.2 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "cweagans/composer-patches": "^1.6.5",
     "drupal/admin_toolbar": "^2.0",
     "drupal/adminimal_admin_toolbar": "^1.9",
-    "drupal/apigee_api_catalog": "^2.1",
+    "drupal/apigee_api_catalog": "^2.2",
     "drupal/apigee_edge": "^1.10",
     "drupal/better_exposed_filters": "^3.0@alpha",
     "drupal/default_content": "^1.0@alpha",


### PR DESCRIPTION
Bumping apigee_api_catalog from 2.1 to 2.2 due to an error when releasing apigee_api_catalog 2.1 (it pointed back to 2.0).