### PR TITLE
[#404] Bump apigee_edge requirement to 8.x-1.14

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "drupal/admin_toolbar": "^2.0",
     "drupal/adminimal_admin_toolbar": "^1.9",
     "drupal/apigee_api_catalog": "^2.2",
-    "drupal/apigee_edge": "^1.13",
+    "drupal/apigee_edge": "^1.14",
     "drupal/better_exposed_filters": "^3.0@alpha",
     "drupal/default_content": "^1.0@alpha",
     "drupal/email_registration": "^1.0@RC",


### PR DESCRIPTION
Bumps the apigee_edge requirement to 8.x-1.14, which should be the new release for apigee_edge that includes this PR: https://github.com/apigee/apigee-edge-drupal/pull/465

**Warning**: should not be merged until https://github.com/apigee/apigee-edge-drupal/pull/465 has been merged and released.

Should fix #404 .