### PR TITLE
#419 CI testing against both D8 and D9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,7 +245,7 @@ workflows:
           name: update-dependencies-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [ 8 ]
+              core-version: [ 8, 9 ]
       - run-code-sniffer:
           requires:
             - update-dependencies-8
@@ -256,21 +256,21 @@ workflows:
           name: run-unit-kernel-tests-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [ 8 ]
+              core-version: [ 8, 9 ]
           requires:
             - update-dependencies-<< matrix.core-version >>
       - run-functional-tests:
           name: run-functional-tests-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [ 8 ]
+              core-version: [ 8, 9 ]
           requires:
             - update-dependencies-<< matrix.core-version >>
       - run-functional-js-tests:
           name: run-functional-js-tests-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [ 8 ]
+              core-version: [ 8, 9 ]
           requires:
             - update-dependencies-<< matrix.core-version >>
 #      - run-code-coverage:

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -16,6 +16,6 @@ apache2-foreground&
 
 robo override:phpunit-config $1
 robo do:extra $2
-composer show
+export SYMFONY_DEPRECATIONS_HELPER=disabled
 
 sudo -E -u www-data vendor/bin/phpunit -c core --group $1 --testsuite unit,kernel --debug --verbose --log-junit /tmp/artifacts/phpunit/phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
     "cweagans/composer-patches": "^1.6.5",
     "drupal/admin_toolbar": "^2.0",
     "drupal/adminimal_admin_toolbar": "^1.9",
-    "drupal/apigee_api_catalog": "^2.2",
-    "drupal/apigee_edge": "^1.15",
+    "drupal/apigee_api_catalog": "^2.4",
+    "drupal/apigee_edge": "^1.16",
     "drupal/better_exposed_filters": "^5.0",
     "drupal/default_content": "^1.0@alpha",
     "drupal/email_registration": "^1.0@RC",
@@ -26,7 +26,8 @@
     "phpstan/phpstan": "0.12.42"
   },
   "conflict": {
-    "drupal/pathauto": "<1.6"
+    "drupal/pathauto": "<1.6",
+    "drupal/apigee_m10n": "<1.7"
   },
   "config": {
     "sort-packages": true

--- a/modules/custom/apigee_kickstart_migrate/apigee_kickstart_migrate_example/apigee_kickstart_migrate_example.info.yml
+++ b/modules/custom/apigee_kickstart_migrate/apigee_kickstart_migrate_example/apigee_kickstart_migrate_example.info.yml
@@ -1,7 +1,7 @@
 name: Apigee Kickstart Migrate Example
 description: "Examples of how to extend Drupal 7 Devportal migrations."
 type: module
-core: 8.x
+core_version_requirement: ^8 || ^9
 package: Examples
 dependencies:
   - drupal:migrate

--- a/themes/custom/apigee_kickstart/apigee_kickstart.info.yml
+++ b/themes/custom/apigee_kickstart/apigee_kickstart.info.yml
@@ -1,6 +1,6 @@
 name: 'Apigee Kickstart'
 description: 'A custom Drupal 8 theme for the Apigee Developer Portal Distribution, based on <a href="https://drupal.org/project/radix">Radix</a>.'
-core: 8.x
+core_version_requirement: ^8 || ^9
 version: VERSION
 type: theme
 base theme: radix

--- a/themes/custom/apigee_kickstart/src/kits/apigee_custom/apigee_custom.info.yml
+++ b/themes/custom/apigee_kickstart/src/kits/apigee_custom/apigee_custom.info.yml
@@ -1,7 +1,7 @@
 name: RADIX_SUBTHEME_NAME
 description: A sub-theme of Apigee Kickstart.
 screenshot: screenshot.png
-core: 8.x
+core_version_requirement: ^8 || ^9
 type: theme
 base theme: apigee_kickstart
 hidden: true


### PR DESCRIPTION
Closes #419. Enables CI testing against both D8 and D9, and requires the latest versions of the apigee modules that are D9 compatible.
Tests are passing now that we released new versions of apigee_edge, apigee_m10n and apigee_api_catalog.

Tests: https://app.circleci.com/pipelines/github/arlina-espinoza/apigee-devportal-kickstart-drupal/10/workflows/c9291580-bfa1-47d0-bd27-5987a2b4c820