### PR TITLE
[#391] Fix an undefined error during update hook when not updating fr…

### DIFF
--- a/apigee_devportal_kickstart.install
+++ b/apigee_devportal_kickstart.install
@@ -447,11 +447,13 @@ function apigee_devportal_kickstart_update_8008() {
     ],
   ];
   foreach ($fields as $field_name => $field_config) {
-    $api_field_config = $definitions[$field_name]->getConfig('apidoc');
+    if (isset($definitions[$field_name])) {
+      $api_field_config = $definitions[$field_name]->getConfig('apidoc');
 
-    // Update the label.
-    if ($api_field_config->getLabel() === $field_config['old_label']) {
-      $definitions[$field_name]->getConfig('apidoc')->setLabel($field_config['label'])->save();
+      // Update the label.
+      if ($api_field_config->getLabel() === $field_config['old_label']) {
+        $definitions[$field_name]->getConfig('apidoc')->setLabel($field_config['label'])->save();
+      }
     }
 
     // Enable the field on the form display.
@@ -550,7 +552,7 @@ function apigee_devportal_kickstart_update_8009() {
     ];
     $display->setOption('exposed_form', $exposed_form);
   }
-  
+
   $display->setOption('filters', $filters);
   $view->save();
 }

--- a/themes/custom/apigee_kickstart/templates/node/node--apidoc--card.html.twig
+++ b/themes/custom/apigee_kickstart/templates/node/node--apidoc--card.html.twig
@@ -17,13 +17,14 @@
   {% set title %}
     <h2 class="card-title">{{ entity.label }}</h2>
   {% endset %}
+  {% set image = content.field_image ?? content.field_image_apidoc %}
 
   {% include '@apigee-kickstart/card/card.twig' with {
     classes: ['api-card'],
     url: content.field_apidoc_file_link['#url'],
-    title: entity.label,
-    image: content.field_image_apidoc,
-    body: content|without('title', 'field_image_apidoc', 'field_apidoc_file_link', 'field_apidoc_spec'),
+    title: title,
+    image: image,
+    body: content|without('title', 'field_image', 'field_image_apidoc', 'field_apidoc_file_link', 'field_apidoc_spec'),
     footer: content.field_apidoc_file_link['#title'],
     hover_shadow: true
   } %}


### PR DESCRIPTION
Fixes an undefined error during the new update hooks that happens if the installation never updated from apigee_api_catalog 1.x, after we merged https://github.com/apigee/apigee-devportal-kickstart-drupal/pull/426. 
Also makes the node card template support the API Doc image field name that comes when installing kickstart or from updating from apigee_api_catalog 1.x.

To test:
1. Install the latest release of Kickstart: `8.x-1.20`.
2. Once installed, replace the kickstart profile with the latest 8.x-1.x code from github.
3. Clear caches and visit `/apis` page. It will look different than the image attached at the last step.
3. Run updates, an error should be displayed.
4. Switch kickstart profile to this PR and run updates. They should complete successfully.
5. Clear caches and visit `/apis` page, it should display the API Doc nodes as cards, like so:
![image](https://user-images.githubusercontent.com/4062676/94732768-8c6ebd00-031b-11eb-813d-d38416ec0954.png)
