### PR TITLE
Call to a member function getValue() on null in ValidReferenceConstraintValidator class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
   "extra": {
     "patches": {
       "drupal/core": {
-        "Fix issue with #summary_details introduced in Drupal 8.6.x": "https://www.drupal.org/files/issues/2018-12-17/core-undefined-index-summary_attributes-2998194-9.patch"
+        "Fix issue with #summary_details introduced in Drupal 8.6.x": "https://www.drupal.org/files/issues/2018-12-17/core-undefined-index-summary_attributes-2998194-9.patch",
+        "Fix Validation issue for entity reference field on updating teams #470": "https://www.drupal.org/files/issues/2021-04-23/validate-reference-constraint-3210319-3.patch"
       },
       "drupal/default_content": {
         "Do not import existing entities": "https://www.drupal.org/files/issues/2020-11-06/default_content-existing-entities-2698425-1-x.patch"


### PR DESCRIPTION
Closes #470 & https://github.com/apigee/apigee-edge-drupal/issues/561
Error while updating Teams with entity reference field throws 
`Error: Call to a member function getValue() on null in Drupal\Core\Entity\Plugin\Validation\Constraint\ValidReferenceConstraintValidator->validate() (line 128`

Fixed this issue by applying patch in composer.json file as this is Drupal core issue.
