### PR TITLE
Resolves apigee m10 - 278 - Change heading variable for buy API to reflect the product name

### DIFF
--- a/themes/custom/apigee_kickstart/templates/apigee/apigee-entity--xrate-plan--teaser.html.twig
+++ b/themes/custom/apigee_kickstart/templates/apigee/apigee-entity--xrate-plan--teaser.html.twig
@@ -144,16 +144,18 @@
   {{ attach_library('apigee_kickstart/monetization') }}
 
   {% set body %}
-    <h2 class="card-title mt-1">
-      <a href="{{ url }}">{{ label }}</a>
-    </h2>
+    {% if content.apiProduct|render %}
+    {% set apiproductName = content.apiProduct|render|striptags %}
+    
+      <h2 class="card-title mt-1">
+        <a href="{{ url }}">{{ apiproductName }}</a>
+      </h2>
+    {% endif %}
 
     {{ content|without('apiProduct') }}
 
-    {% if content.apiProduct|render %}
-      <hr class="my-4">
-      {{ content.apiProduct }}
-    {% endif %}
+    <hr class="my-4">
+    {{ label }}
 
     {% include '@apigee-kickstart/button/button-link.twig' with {
       'type': 'primary',


### PR DESCRIPTION
Closes https://github.com/apigee/apigee-m10n-drupal/issues/278

Made Product name a heading and moved the rate plan name to the description.
This change is done for Apigee X BuyAPI listing page for apigee-devportal-kickstart-drupal and m10 module both.