### PR TITLE
Removed the required attribute for the "Specification source type" field

### DIFF
--- a/config/install/field.field.node.apidoc.field_apidoc_spec_file_source.yml
+++ b/config/install/field.field.node.apidoc.field_apidoc_spec_file_source.yml
@@ -14,7 +14,7 @@ entity_type: node
 bundle: apidoc
 label: 'Specification source type'
 description: 'Indicate if the OpenAPI spec will be provided as a file for upload or a URL.'
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
This PR is related to https://github.com/apigee/apigee-api-catalog-drupal/issues/116, removes the required attribute for the "Specification source type" field for API Doc when installing kickstart.