### PR TITLE
Checks if ApigeeX and gives option to install m10 module

### DIFF
--- a/src/Installer/ApigeeDevportalKickstartMonetization.php
+++ b/src/Installer/ApigeeDevportalKickstartMonetization.php
@@ -38,7 +38,13 @@ class ApigeeDevportalKickstartMonetization {
       $sdk_connector = \Drupal::service('apigee_edge.sdk_connector');
       $organization_controller = new OrganizationController($sdk_connector->getClient());
       $organization = $organization_controller->load($sdk_connector->getOrganization());
-      return ($organization->getPropertyValue('features.isMonetizationEnabled') === 'true');
+      // Check if org is Hybrid or ApigeeX.
+      if ($organization && ('CLOUD' === $organization->getRuntimeType() || 'HYBRID' === $organization->getRuntimeType()) && $organization->getAddonsConfig()) {
+        return (TRUE === $organization->getAddonsConfig()->getMonetizationConfig()->getEnabled());
+      }
+      else {
+        return ($organization->getPropertyValue('features.isMonetizationEnabled') === 'true');
+      }
     }
     catch (\Exception $exception) {
       // Do not log the exception here. This litters the logs since this is run


### PR DESCRIPTION
This PR fixes #494 .
During installation this PR lets you enable monetization module if ApigeeX org is used. Option to enable 'Add credit' sub module will not be visible as currently ApigeeX does not support prepaid functionality. 