### PR TITLE
Removed "apigee_m10n" module from dependencies

### DIFF
--- a/src/Installer/ApigeeDevportalKickstartMonetization.php
+++ b/src/Installer/ApigeeDevportalKickstartMonetization.php
@@ -100,7 +100,6 @@ class ApigeeDevportalKickstartMonetization {
   protected static function dependencies(): array {
     return [
       'address',
-      'apigee_m10n',
       'commerce',
     ];
   }


### PR DESCRIPTION
Closes #512 

Removed "`apigee_m10n`" module from dependencies which was causing "`Enable Monetization`" checkbox functionality issue which gives option to the user to enable/disable the module while installation.
(_As the dependencies array contains the "`apigee_m10n`" module, it installs the modules regardless checkbox disabled._)

This PR fix the "`Enable Monetization`" checkbox issue, which enables the `apigee_m10n` module even if the "`Enable Monetization"` checkbox was unchecked.