### PR TITLE
Removed the yml extension from field_apidoc_file_link and field_apidoc_spec allowed values

### DIFF
--- a/config/install/field.field.node.apidoc.field_apidoc_file_link.yml
+++ b/config/install/field.field.node.apidoc.field_apidoc_file_link.yml
@@ -21,6 +21,6 @@ default_value_callback: ''
 settings:
   link_type: 17
   title: 0
-  file_extensions: 'yml yaml json'
+  file_extensions: 'yaml json'
   no_extension: false
 field_type: file_link

--- a/config/install/field.field.node.apidoc.field_apidoc_spec.yml
+++ b/config/install/field.field.node.apidoc.field_apidoc_spec.yml
@@ -20,7 +20,7 @@ default_value: {  }
 default_value_callback: ''
 settings:
   file_directory: apidoc_specs
-  file_extensions: 'yml yaml json'
+  file_extensions: 'yaml json'
   max_filesize: ''
   description_field: false
   handler: 'default:file'


### PR DESCRIPTION
Fix https://github.com/apigee/apigee-api-catalog-drupal/issues/152

Removed .yml extension from field_apidoc_file_link and field_apidoc_spec allowed values because in Drupal 8+ .yml can contain sensitive information which can cause security issues.