### PR TITLE
Drop Drupal 9.2 from testing

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -35,6 +35,7 @@ jobs:
         drupal-core:
           # Should update the following as the minimum supported version from Drupal.org
           - "9.3.x"
+          - "9.4.x"
 #        include:
 #           - php-version: "8.1"
 #             drupal-core: "10.0.x-dev"

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -34,11 +34,7 @@ jobs:
           - "8.1"
         drupal-core:
           # Should update the following as the minimum supported version from Drupal.org
-          - "9.2.x"
           - "9.3.x"
-        exclude:
-           - php-version: "8.1"
-             drupal-core: "9.2.x"
 #        include:
 #           - php-version: "8.1"
 #             drupal-core: "10.0.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "drupal/core-dev": "^9",
     "drush/drush": "^10.0",
     "mglaman/drupal-check": "^1.3",
-    "phpmd/phpmd": "2.8.2",
+    "phpmd/phpmd": "^2.8.2",
     "phpmetrics/phpmetrics": "^2.5",
     "phpstan/phpstan": "^1.5"
   },


### PR DESCRIPTION
Fixes #578 
Removed Drupal 9.2 and added support for Drupal 9.4.