### PR TITLE
Fix for Deprecation htmlspecialchars(): Passing null to parameter #1($string) of type string

### DIFF
--- a/themes/custom/apigee_kickstart/templates/apigee/rate-plan-detail.html.twig
+++ b/themes/custom/apigee_kickstart/templates/apigee/rate-plan-detail.html.twig
@@ -107,8 +107,9 @@
           <tr>
             <td>
               {%- set endUnitStr = rate.endUnit ?  'up to'|t  : '' -%}
+              {%- set endUnit = rate.endUnit ?  rate.endUnit : '' -%}
               {%- trans -%}
-                Greater than {{ rate.startUnit }} {{ endUnitStr }} {{ rate.endUnit }}
+                Greater than {{ rate.startUnit }} {{ endUnitStr }} {{ endUnit }}
               {%- endtrans -%}
             </td>
             <td>{{ rate.rate }}</td>
@@ -131,10 +132,11 @@
         <tbody>
           {%- for rate in revshare_rates -%}
             {%- set endUnitStr = rate.endUnit ?  'up to'|t  : '' -%}
+            {%- set endUnit = rate.endUnit ?  rate.endUnit : '' -%}
             <tr>
               <td>
                 {%- trans -%}
-                  Greater than {{ rate.startUnit }} {{ endUnitStr }} {{ rate.endUnit }}
+                  Greater than {{ rate.startUnit }} {{ endUnitStr }} {{ endUnit }}
                 {%- endtrans -%}
               </td>
               <td>{{ rate.revshare }}</td>


### PR DESCRIPTION
Fixes https://github.com/apigee/apigee-m10n-drupal/issues/384 .