### PR TITLE
Fix missing alternative text - accessibility issues (VPAT)

### DIFF
--- a/themes/custom/apigee_kickstart/includes/node.inc
+++ b/themes/custom/apigee_kickstart/includes/node.inc
@@ -5,6 +5,9 @@
  * Theme and preprocess functions for nodes.
  */
 
+use Drupal\media\Entity\Media;
+use Drupal\paragraphs\Entity\Paragraph;
+
 /**
  * Implements hook_preprocess_node().
  */
@@ -56,6 +59,97 @@ function apigee_kickstart_preprocess_node(&$variables) {
     if ($variables['view_mode'] !== 'full') {
       $variables['content']['field_apidoc_file_link'] = $node->toLink(t('View Documentation'))
         ->toRenderable();
+    }
+  }
+
+  // Web accessibility standards
+  // When Home page - Hero section is rendered add the alternative text
+  // for missing alt text for images.
+  if ($node->hasfield('field_header')) {
+    foreach ($node->get('field_header') as $paragraph) {
+      if ($paragraph->entity->getType() == 'hero') {
+        $paragraph_featured_apis = $paragraph->entity;
+        if (!empty($paragraph_featured_apis)) {
+          foreach ($paragraph_featured_apis->get('field_media') as $reference) {
+            $media = Media::load($reference->target_id);
+            $media_field = $media->get('field_media_image')->first()->getValue();
+            $field_title = $paragraph_featured_apis->get('field_title')->first()->getValue();
+
+            // Adding node title as alternative text (Web accessibility standards)
+            if ($media_field["alt"] === NULL) {
+              $media_field["alt"] = $field_title;
+              $media->set('field_media_image', $media_field);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Web accessibility standards
+  // When Home page - Featured-APIs section is rendered add the alternative text
+  // for missing alt text for images.
+  if ($node->hasfield('field_content')) {
+    foreach ($node->get('field_content') as $paragraph) {
+      if ($paragraph->entity->getType() == 'card_group') {
+        $paragraph_featured_apis = $paragraph->entity;
+        if (!empty($paragraph_featured_apis)) {
+          foreach ($paragraph_featured_apis->get('field_cards') as $reference) {
+
+            $paragraph_cards = Paragraph::load($reference->target_id);
+            $field_image = $paragraph_cards->get('field_image')->first()->getValue();
+            $field_title = $paragraph_cards->get('field_title')->first()->getValue();
+            $media = Media::load($field_image['target_id']);
+            $media_field = $media->get('field_media_image')->first()->getValue();
+
+            // Adding card title as alternative text (Web accessibility standards)
+            if ($media_field["alt"] === NULL) {
+              $media_field["alt"] = $field_title;
+              $media->set('field_media_image', $media_field);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Web accessibility standards
+  // When Home page - Text and image section is rendered add the alternative text
+  // for missing alt text for images.
+  if ($node->hasfield('field_content')) {
+    foreach ($node->get('field_content') as $paragraph) {
+      if ($paragraph->entity->getType() == 'text_image') {
+        $paragraph_featured_apis = $paragraph->entity;
+        if (!empty($paragraph_featured_apis)) {
+          foreach ($paragraph_featured_apis->get('field_image') as $reference) {
+            $media = Media::load($reference->target_id);
+            $media_field = $media->get('field_media_image')->first()->getValue();
+            $field_title = $paragraph_featured_apis->get('field_title')->first()->getValue();
+
+            // Adding node title as alternative text (Web accessibility standards)
+            if ($media_field["alt"] === NULL) {
+              $media_field["alt"] = $field_title;
+              $media->set('field_media_image', $media_field);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Web accessibility standards
+  // When Apis listing page is rendered add the alternative text
+  // for missing alt text for images.
+  if ($node->hasfield('field_image')) {
+    foreach ($node->field_image as $reference) {
+      $media = Media::load($reference->target_id);
+      $media_field = $media->get('field_media_image')->first()->getValue();
+
+      // Adding node title as alternative text (Web accessibility standards)
+      if ($media_field["alt"] === NULL) {
+        $media_field["alt"] = $node->label();
+        $media->set('field_media_image', $media_field);
+      }
     }
   }
 }


### PR DESCRIPTION
Fix #581 
Fix accessibility issues `missing alternative text` for media image.
On rendering the page dynamically adding the `alternative text` for missing alt text on Apigee demo content to conform to 508 Standards.