### PR TITLE
Fix for twig syntax error in twig 3

### DIFF
--- a/themes/custom/apigee_kickstart/templates/forum/forum-list.html.twig
+++ b/themes/custom/apigee_kickstart/templates/forum/forum-list.html.twig
@@ -27,7 +27,7 @@
           depth this forum resides at. This will allow us to use CSS
           left-margin for indenting.
         #}
-        {% for i in 1..forum.depth if forum.depth > 0 %}<div class="indented">{% endfor %}
+        {% if forum.depth > 0 %}{% for i in 1..forum.depth %}<div class="indented">{% endfor %}{% endif %}
           <div class="forum__icon forum-status-{{ forum.icon_class }}" title="{{ forum.icon_title }}">
             <span class="visually-hidden">{{ forum.icon_title }}</span>
           </div>
@@ -40,7 +40,7 @@
           {% if forum.description.value %}
             <div class="forum__description text-muted mt-1">{{ forum.description.value }}</div>
           {% endif %}
-          {% for i in 1..forum.depth if forum.depth > 0 %}</div>{% endfor %}
+        {% if forum.depth > 0 %}{% for i in 1..forum.depth %}</div>{% endfor %}{% endif %}
       </td>
       {% if forum.is_container == false %}
         <td class="forum__topics pt-4 pb-2">


### PR DESCRIPTION
Fixes #628 
Support for the 'if' clause has been removed from for statements is removed from twig 3.