### PR TITLE
Fix for homepage and apidoc render issue

### DIFF
--- a/config/install/core.entity_form_display.node.landing.default.yml
+++ b/config/install/core.entity_form_display.node.landing.default.yml
@@ -61,6 +61,13 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    weight: 8
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
@@ -92,5 +99,3 @@ content:
       placeholder: ''
     region: content
     third_party_settings: {  }
-hidden:
-  promote: true

--- a/config/install/pathauto.pattern.apidoc.yml
+++ b/config/install/pathauto.pattern.apidoc.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: apidoc
+label: ApiDoc
+type: 'canonical_entities:node'
+pattern: '/api/[node:nid]'
+selection_criteria:
+  5de03b94-61e7-49b2-9112-cbfabd42ee75:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: 5de03b94-61e7-49b2-9112-cbfabd42ee75
+    context_mapping:
+      node: node
+    bundles:
+      apidoc: apidoc
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/config/install/system.site.yml
+++ b/config/install/system.site.yml
@@ -5,7 +5,7 @@ slogan: ''
 page:
   403: ''
   404: ''
-  front: /node
+  front: /home
 admin_compact_mode: false
 weight_select_max: 100
 langcode: en

--- a/modules/custom/apigee_kickstart_content/content/node/3890114e-688b-4c8e-9a87-e74a22b0e456.yml
+++ b/modules/custom/apigee_kickstart_content/content/node/3890114e-688b-4c8e-9a87-e74a22b0e456.yml
@@ -25,7 +25,7 @@ default:
       value: 1552792430
   promote:
     -
-      value: true
+      value: false
   sticky:
     -
       value: false

--- a/modules/custom/apigee_kickstart_content/content/node/41e9956a-c127-4884-8a27-4ff70cf02dcb.yml
+++ b/modules/custom/apigee_kickstart_content/content/node/41e9956a-c127-4884-8a27-4ff70cf02dcb.yml
@@ -35,7 +35,6 @@ default:
       value: true
   path:
     -
-      alias: /api/38
       langcode: en
       pathauto: 0
   body:

--- a/modules/custom/apigee_kickstart_content/content/node/7c30dc66-b866-4b9d-8351-0de09bee8094.yml
+++ b/modules/custom/apigee_kickstart_content/content/node/7c30dc66-b866-4b9d-8351-0de09bee8094.yml
@@ -25,7 +25,7 @@ default:
       value: 1552793259
   promote:
     -
-      value: true
+      value: false
   sticky:
     -
       value: false

--- a/modules/custom/apigee_kickstart_content/content/node/7fde3835-2c65-4df2-abd4-227eab08098a.yml
+++ b/modules/custom/apigee_kickstart_content/content/node/7fde3835-2c65-4df2-abd4-227eab08098a.yml
@@ -25,7 +25,7 @@ default:
       value: 1552792649
   promote:
     -
-      value: true
+      value: false
   sticky:
     -
       value: false

--- a/modules/custom/apigee_kickstart_content/content/node/88696329-c494-40c5-9339-dfaab375f092.yml
+++ b/modules/custom/apigee_kickstart_content/content/node/88696329-c494-40c5-9339-dfaab375f092.yml
@@ -25,7 +25,7 @@ default:
       value: 1552794469
   promote:
     -
-      value: true
+      value: false
   sticky:
     -
       value: false

--- a/modules/custom/apigee_kickstart_content/content/node/a1f3163b-fbfa-44aa-bf78-fbd20ff05744.yml
+++ b/modules/custom/apigee_kickstart_content/content/node/a1f3163b-fbfa-44aa-bf78-fbd20ff05744.yml
@@ -26,7 +26,7 @@ default:
       value: 1594581257
   promote:
     -
-      value: true
+      value: false
   sticky:
     -
       value: false
@@ -35,7 +35,6 @@ default:
       value: true
   path:
     -
-      alias: /api/44
       langcode: en
       pathauto: 0
   body:

--- a/modules/custom/apigee_kickstart_content/content/node/acf16bcc-b4f1-4dc4-8240-ceb98007d2ee.yml
+++ b/modules/custom/apigee_kickstart_content/content/node/acf16bcc-b4f1-4dc4-8240-ceb98007d2ee.yml
@@ -6,8 +6,11 @@ _meta:
   default_langcode: en
   depends:
     f254c054-c4a1-46ff-80c2-6eff444ce5bd: media
+    c3f5bde5-c21b-42e5-ad2e-2501169c60c4: node
     e5ef1b62-468c-42be-a305-d0005c029619: media
+    a1f3163b-fbfa-44aa-bf78-fbd20ff05744: node
     79f038c1-8e9e-46fb-ac60-8ab17854492a: media
+    b6923412-a1c4-46cc-9b93-cf4b494cc2cd: node
     35dc3dd9-205d-4fea-954f-39297c71b50f: node
     7517d587-e652-4a9c-86c3-09ee39db5232: media
     08ad78f2-dcad-403e-8ca6-4c2ae1555216: media
@@ -29,7 +32,7 @@ default:
       value: 1552669388
   promote:
     -
-      value: false
+      value: true
   sticky:
     -
       value: false
@@ -142,7 +145,7 @@ default:
                       entity: f254c054-c4a1-46ff-80c2-6eff444ce5bd
                   field_link:
                     -
-                      uri: 'internal:/api/40'
+                      target_uuid: c3f5bde5-c21b-42e5-ad2e-2501169c60c4
                       title: 'View Documentation'
                       options: {  }
                   field_text:
@@ -175,7 +178,7 @@ default:
                       entity: e5ef1b62-468c-42be-a305-d0005c029619
                   field_link:
                     -
-                      uri: 'internal:/api/44'
+                      target_uuid: a1f3163b-fbfa-44aa-bf78-fbd20ff05744
                       title: 'View Documentation'
                       options: {  }
                   field_text:
@@ -208,7 +211,7 @@ default:
                       entity: 79f038c1-8e9e-46fb-ac60-8ab17854492a
                   field_link:
                     -
-                      uri: 'internal:/api/43'
+                      target_uuid: b6923412-a1c4-46cc-9b93-cf4b494cc2cd
                       title: 'View Documentation'
                       options: {  }
                   field_text:

--- a/modules/custom/apigee_kickstart_content/content/node/b2c0cd78-5d9a-46ef-948e-6a73c601d442.yml
+++ b/modules/custom/apigee_kickstart_content/content/node/b2c0cd78-5d9a-46ef-948e-6a73c601d442.yml
@@ -27,7 +27,7 @@ default:
       value: 1594581553
   promote:
     -
-      value: true
+      value: false
   sticky:
     -
       value: false
@@ -36,7 +36,6 @@ default:
       value: true
   path:
     -
-      alias: /api/36
       langcode: en
       pathauto: 0
   body:

--- a/modules/custom/apigee_kickstart_content/content/node/b6923412-a1c4-46cc-9b93-cf4b494cc2cd.yml
+++ b/modules/custom/apigee_kickstart_content/content/node/b6923412-a1c4-46cc-9b93-cf4b494cc2cd.yml
@@ -26,7 +26,7 @@ default:
       value: 1594581384
   promote:
     -
-      value: true
+      value: false
   sticky:
     -
       value: false
@@ -35,7 +35,6 @@ default:
       value: true
   path:
     -
-      alias: /api/43
       langcode: en
       pathauto: 0
   body:

--- a/modules/custom/apigee_kickstart_content/content/node/c3f5bde5-c21b-42e5-ad2e-2501169c60c4.yml
+++ b/modules/custom/apigee_kickstart_content/content/node/c3f5bde5-c21b-42e5-ad2e-2501169c60c4.yml
@@ -27,7 +27,7 @@ default:
       value: 1594581428
   promote:
     -
-      value: true
+      value: false
   sticky:
     -
       value: false
@@ -36,7 +36,6 @@ default:
       value: true
   path:
     -
-      alias: /api/40
       langcode: en
       pathauto: 0
   body:

--- a/modules/custom/apigee_kickstart_content/content/node/cb3564b6-5bdc-4c75-b7f0-07b5f5b50ee4.yml
+++ b/modules/custom/apigee_kickstart_content/content/node/cb3564b6-5bdc-4c75-b7f0-07b5f5b50ee4.yml
@@ -27,7 +27,7 @@ default:
       value: 1594581503
   promote:
     -
-      value: true
+      value: false
   sticky:
     -
       value: false
@@ -36,7 +36,6 @@ default:
       value: true
   path:
     -
-      alias: /api/34
       langcode: en
       pathauto: 0
   body:

--- a/src/Installer/Form/DemoInstallForm.php
+++ b/src/Installer/Form/DemoInstallForm.php
@@ -115,11 +115,6 @@ class DemoInstallForm extends FormBase {
 
     if ($demo_content) {
       $this->moduleInstaller->install(['apigee_kickstart_content']);
-
-      // Set the front page to node 1.
-      $this->configFactory->getEditable('system.site')
-        ->set('page.front', '/node/41')
-        ->save();
     }
   }
 

--- a/themes/custom/apigee_kickstart/assets/css/apigee-kickstart.style.css
+++ b/themes/custom/apigee_kickstart/assets/css/apigee-kickstart.style.css
@@ -4681,7 +4681,8 @@ input[type=button].btn-block {
     transition: none;
   }
 }
-a.badge:hover, a.badge:focus {
+a.badge:hover, a.badge:focus,
+.article__tags .field__item a:hover, .article__tags .field__item a:focus {
   text-decoration: none;
 }
 
@@ -4782,9 +4783,15 @@ a.badge-danger:focus, a.badge-danger.focus {
   color: #3c3c3c;
   background-color: #f0f0f0;
 }
+.article__tags .field__item a {
+  color: #3c3c3c;
+}
 a.badge-light:hover, a.badge-light:focus {
   color: #3c3c3c;
   background-color: #d7d7d7;
+}
+.article__tags .field__item:hover , .article__tags .field__item:focus  {
+  color: #3c3c3c;
 }
 a.badge-light:focus, a.badge-light.focus {
   outline: 0;
@@ -12849,7 +12856,8 @@ form.team-member-form .form-checkboxes small {
 .article__tags {
   margin-bottom: 1rem;
 }
-.article__tags .badge {
+.article__tags .badge,
+.article__tags .field__item a {
   text-transform: uppercase;
   font-weight: 500;
   letter-spacing: 1.5px;
@@ -12860,7 +12868,8 @@ form.team-member-form .form-checkboxes small {
 .article__tags .badge + .badge {
   margin-left: 1rem;
 }
-.article__tags .badge:hover {
+.article__tags .badge:hover,
+.article__tags .field__item a:hover {
   background: none;
   color: #2196f3;
 }

--- a/themes/custom/apigee_kickstart/config/install/block.block.apigee_kickstart_breadcrumbs.yml
+++ b/themes/custom/apigee_kickstart/config/install/block.block.apigee_kickstart_breadcrumbs.yml
@@ -19,6 +19,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: '/article/*\r\n/blog/*'
+    pages: '<front>'
     negate: true
     context_mapping: {  }


### PR DESCRIPTION
Fixes #637 
Resolves:
1.Homepage content render.
2.Api doc render. This was cause of node id miss match.
3.Applied css for blog tags name on page /blog.