### PR TITLE
Removed Hal module version lock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "drupal/color": "^1.0",
     "drupal/quickedit": "^1.0",
     "drupal/rdf": "^2.1",
-    "drupal/hal": "1.0 || 2.0"
+    "drupal/hal": "^1.0 || ^2.0"
   },
   "require-dev": {
     "drupal/core-dev": "^9.4 || ^10.0",


### PR DESCRIPTION
Closes [#643](https://github.com/apigee/apigee-devportal-kickstart-drupal/issues/643)
Removed Hal version lock