### PR TITLE
Replacement for deprecated class sr-only for Bootstrap 5

### DIFF
--- a/themes/custom/apigee_kickstart/src/sass/form/_form.search-form.scss
+++ b/themes/custom/apigee_kickstart/src/sass/form/_form.search-form.scss
@@ -6,7 +6,7 @@ form.search-form {
   font-size: 0.875rem;
 
   .search-help-link {
-    @include visually-hidden();
+    @include visually-hidden;
   }
 
   fieldset {

--- a/themes/custom/apigee_kickstart/src/sass/page/_page.search.scss
+++ b/themes/custom/apigee_kickstart/src/sass/page/_page.search.scss
@@ -34,7 +34,7 @@
     }
 
     .page__content > h2 {
-      @include visually-hidden();
+      @include visually-hidden;
     }
   }
 

--- a/themes/custom/apigee_kickstart/templates/block/block--system-menu-block.html.twig
+++ b/themes/custom/apigee_kickstart/templates/block/block--system-menu-block.html.twig
@@ -5,7 +5,7 @@
  */
 #}
 
-{% set title_attributes = title_attributes.setAttribute('class', ['sr-only', 'd-none']) %}
+{% set title_attributes = title_attributes.setAttribute('class', ['visually-hidden']) %}
 
 {% include '@radix/block/block.twig' with {
   html_tag: 'div',


### PR DESCRIPTION
Replacement for deprecated class 'sr-only' in Bootstrap 5.