### PR TITLE
Patch added for Missing message theme suggestions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
     "patches": {
       "drupal/core": {
         "Fix issue with #summary_details introduced in Drupal 8.6.x": "https://www.drupal.org/files/issues/2018-12-17/core-undefined-index-summary_attributes-2998194-9.patch",
-        "Fix Validation issue for entity reference field on updating teams #470": "https://www.drupal.org/files/issues/2021-04-23/validate-reference-constraint-3210319-3.patch"
+        "Fix Validation issue for entity reference field on updating teams #470": "https://www.drupal.org/files/issues/2021-04-23/validate-reference-constraint-3210319-3.patch",
+        "Fix Drupal 10.3 upgrade issue of missing status-message theme suggestions": "https://www.drupal.org/files/issues/2024-06-28/3456176-45-missing-status-messages-theme-suggestions.patch"
       },
       "drupal/default_content": {
         "Do not import existing entities": "https://www.drupal.org/files/issues/2022-07-29/default_content-fix-uuid-duplicate-entry-2698425.patch"


### PR DESCRIPTION
Fixes #709 

This is a Drupal 10.3 issue as explained [here](https://www.drupal.org/project/drupal/issues/3456176).

Solution is added in [45 comment](https://www.drupal.org/project/drupal/issues/3456176#comment-15661382).