### PR TITLE
Updated modules for Drupal 11 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,9 @@
     "drupal/radix": "^6.0.1",
     "drupal/components": "^3.1.0",
     "drupal/rdf": "^3.0@beta",
-    "drupal/hal": "^2.0.4"
+    "drupal/hal": "^2.0.4",
+    "drupal/tour": "^2.0",
+    "drupal/forum": "^1.0"
   },
   "require-dev": {
     "drupal/core-dev": "^10.3 || ^11.1",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "drupal/pathauto": "^1.13",
     "drupal/radix": "^6.0.1",
     "drupal/components": "^3.1.0",
-    "drupal/rdf": "^3.0@beta2",
+    "drupal/rdf": "^3.0@beta",
     "drupal/hal": "^2.0.4"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,30 +14,30 @@
     }
   ],
   "require": {
-    "cweagans/composer-patches": "^1.6.5",
-    "drupal/admin_toolbar": "^3.0",
-    "drupal/apigee_api_catalog": "^3",
-    "drupal/apigee_edge": "^3.0.8",
-    "drupal/better_exposed_filters": "^6.0",
+    "cweagans/composer-patches": "^1.7.3",
+    "drupal/admin_toolbar": "^3.5.3",
+    "drupal/apigee_api_catalog": "dev-d11-prep",
+    "drupal/apigee_edge": "^3.0.8 || ^4.0.0",
+    "drupal/better_exposed_filters": "^7.0.5",
     "drupal/default_content": "^2.0@alpha",
-    "drupal/email_registration": "^1.2",
-    "drupal/fontawesome": "^2.12",
-    "drupal/paragraphs": "^1.6",
-    "drupal/pathauto": "^1.6",
-    "drupal/radix": "^5.0",
-    "drupal/components": "^3.0@beta",
+    "drupal/email_registration": "^2.0@rc7",
+    "drupal/fontawesome": "^3.0.0",
+    "drupal/paragraphs": "^1.18",
+    "drupal/pathauto": "^1.13",
+    "drupal/radix": "^6.0.1",
+    "drupal/components": "^3.1.0",
     "drupal/color": "^1.0",
     "drupal/quickedit": "^1.0",
-    "drupal/rdf": "^2.1",
-    "drupal/hal": "^2.0"
+    "drupal/rdf": "^3.0@beta2",
+    "drupal/hal": "^2.0.4"
   },
   "require-dev": {
-    "drupal/core-dev": "^10.2",
-    "drush/drush": "^12.4.3",
-    "mglaman/drupal-check": "^1.3",
+    "drupal/core-dev": "^10.3 || ^11.1",
+    "drush/drush": "^13.3",
+    "mglaman/drupal-check": "^1.5",
     "phpmd/phpmd": "^2.8.2",
     "phpmetrics/phpmetrics": "^2.5",
-    "phpstan/phpstan": "^1.5"
+    "phpstan/phpstan": "^1.12"
   },
   "config": {
     "sort-packages": true
@@ -51,6 +51,9 @@
       },
       "drupal/default_content": {
         "Do not import existing entities": "https://www.drupal.org/files/issues/2022-07-29/default_content-fix-uuid-duplicate-entry-2698425.patch"
+      },
+      "drupal/file_link": {
+        "Drupal 11 support added": "https://git.drupalcode.org/project/file_link/-/merge_requests/14.patch"
       }
     }
   }

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,6 @@
     "drupal/pathauto": "^1.13",
     "drupal/radix": "^6.0.1",
     "drupal/components": "^3.1.0",
-    "drupal/color": "^1.0",
-    "drupal/quickedit": "^1.0",
     "drupal/rdf": "^3.0@beta2",
     "drupal/hal": "^2.0.4"
   },
@@ -53,7 +51,7 @@
         "Do not import existing entities": "https://www.drupal.org/files/issues/2022-07-29/default_content-fix-uuid-duplicate-entry-2698425.patch"
       },
       "drupal/file_link": {
-        "Drupal 11 support added": "https://git.drupalcode.org/project/file_link/-/merge_requests/14.patch"
+        "Drupal 11 support added": "https://www.drupal.org/files/issues/2025-02-27/drupal11_support-3430560.patch"
       }
     }
   }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "cweagans/composer-patches": "^1.7.3",
     "drupal/admin_toolbar": "^3.5.3",
-    "drupal/apigee_api_catalog": "dev-d11-prep",
+    "drupal/apigee_api_catalog": "^3.0.9",
     "drupal/apigee_edge": "^3.0.8 || ^4.0.0",
     "drupal/better_exposed_filters": "^7.0.5",
     "drupal/default_content": "^2.0@alpha",

--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,9 @@
   },
   "require-dev": {
     "drupal/core-dev": "^10.3 || ^11.1",
-    "drush/drush": "^13.3",
+    "drush/drush": "^12.4.3 || ^13.3",
     "mglaman/drupal-check": "^1.5",
-    "phpmd/phpmd": "^2.8.2",
+    "phpmd/phpmd": "^2.15.0",
     "phpmetrics/phpmetrics": "^2.5",
     "phpstan/phpstan": "^1.12"
   },

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "drupal/apigee_edge": "^3.0.8 || ^4.0.0",
     "drupal/better_exposed_filters": "^7.0.5",
     "drupal/default_content": "^2.0@alpha",
-    "drupal/email_registration": "^2.0@rc7",
+    "drupal/email_registration": "^2.0@rc8",
     "drupal/fontawesome": "^3.0.0",
     "drupal/paragraphs": "^1.18",
     "drupal/pathauto": "^1.13",

--- a/composer.json
+++ b/composer.json
@@ -51,9 +51,6 @@
       },
       "drupal/default_content": {
         "Do not import existing entities": "https://www.drupal.org/files/issues/2022-07-29/default_content-fix-uuid-duplicate-entry-2698425.patch"
-      },
-      "drupal/file_link": {
-        "Drupal 11 support added": "https://www.drupal.org/files/issues/2025-02-27/drupal11_support-3430560.patch"
       }
     }
   }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "drupal/apigee_edge": "^3.0.8 || ^4.0.0",
     "drupal/better_exposed_filters": "^7.0.5",
     "drupal/default_content": "^2.0@alpha",
-    "drupal/email_registration": "^2.0@rc8",
+    "drupal/email_registration": "^2.0@rc",
     "drupal/fontawesome": "^3.0.0",
     "drupal/paragraphs": "^1.18",
     "drupal/pathauto": "^1.13",


### PR DESCRIPTION
Fixes #713 

Removed Quickedit & color modules from here as they are unsupported from Drupal 11 - https://www.drupal.org/docs/core-modules-and-themes/deprecated-and-obsolete#s-quick-edit