### PR TITLE
Added Drupal 11 support for themes and modules

### DIFF
--- a/apigee_devportal_kickstart.info.yml
+++ b/apigee_devportal_kickstart.info.yml
@@ -1,7 +1,7 @@
 name: Apigee Developer Portal Kickstart
 type: profile
 description: 'A fast demo and starting point for Apigee Developer Portals.'
-core_version_requirement: ^10
+core_version_requirement: ^10 || ^11
 
 # Optional: Declare your installation profile as a distribution
 # This will make the installer auto-select this installation profile.

--- a/apigee_devportal_kickstart.info.yml
+++ b/apigee_devportal_kickstart.info.yml
@@ -47,6 +47,7 @@ install:
 - rdf
 - views
 - views_ui
+- tour
 - automated_cron
 - media
 - media_library

--- a/apigee_devportal_kickstart.info.yml
+++ b/apigee_devportal_kickstart.info.yml
@@ -28,7 +28,6 @@ install:
 - menu_link_content
 - datetime
 - block_content
-- quickedit
 - editor
 - help
 - image
@@ -48,7 +47,6 @@ install:
 - rdf
 - views
 - views_ui
-- tour
 - automated_cron
 - media
 - media_library

--- a/modules/custom/apigee_kickstart_content/apigee_kickstart_content.info.yml
+++ b/modules/custom/apigee_kickstart_content/apigee_kickstart_content.info.yml
@@ -1,7 +1,7 @@
 name: Apigee Kickstart Content
 description: "Provides demo content for Apigee Developer Portal Kickstart."
 type: module
-core_version_requirement: ^10
+core_version_requirement: ^10 || ^11
 package: Apigee Kickstart
 dependencies:
   - default_content:default_content

--- a/modules/custom/apigee_kickstart_customizer/apigee_kickstart_customizer.info.yml
+++ b/modules/custom/apigee_kickstart_customizer/apigee_kickstart_customizer.info.yml
@@ -1,5 +1,5 @@
 name: Apigee Kickstart Customizer
 description: "Provides a UI for customizing the Apigee Kickstart theme."
 type: module
-core_version_requirement: ^10
+core_version_requirement: ^10 || ^11
 package: Apigee Kickstart

--- a/modules/custom/apigee_kickstart_enhancement/apigee_kickstart_enhancement.info.yml
+++ b/modules/custom/apigee_kickstart_enhancement/apigee_kickstart_enhancement.info.yml
@@ -1,7 +1,7 @@
 name: Apigee Kickstart Enhancement
 description: "Provides enhancement for Apigee Edge module."
 type: module
-core_version_requirement: ^10
+core_version_requirement: ^10 || ^11
 package: Apigee Kickstart
 dependencies:
   - apigee_edge:apigee_edge

--- a/modules/custom/apigee_kickstart_migrate/apigee_kickstart_migrate.info.yml
+++ b/modules/custom/apigee_kickstart_migrate/apigee_kickstart_migrate.info.yml
@@ -1,7 +1,7 @@
 name: Apigee Kickstart Migrate
 description: "Provides a migration path from Drupal 7 Devportal to Drupal 8 Kickstart."
 type: module
-core_version_requirement: ^10
+core_version_requirement: ^10 || ^11
 package: Apigee Kickstart
 dependencies:
   - drupal:migrate

--- a/modules/custom/apigee_kickstart_migrate/apigee_kickstart_migrate_example/apigee_kickstart_migrate_example.info.yml
+++ b/modules/custom/apigee_kickstart_migrate/apigee_kickstart_migrate_example/apigee_kickstart_migrate_example.info.yml
@@ -1,7 +1,7 @@
 name: Apigee Kickstart Migrate Example
 description: "Examples of how to extend Drupal 7 Devportal migrations."
 type: module
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^8 || ^9 || ^10 || ^11
 package: Examples
 dependencies:
   - drupal:migrate

--- a/themes/custom/apigee_kickstart/apigee_kickstart.info.yml
+++ b/themes/custom/apigee_kickstart/apigee_kickstart.info.yml
@@ -1,6 +1,6 @@
 name: 'Apigee Kickstart'
 description: 'A custom Drupal theme for the Apigee Developer Portal Distribution, based on <a href="https://drupal.org/project/radix">Radix</a>.'
-core_version_requirement: ^10
+core_version_requirement: ^10 || ^11
 version: VERSION
 type: theme
 base theme: radix

--- a/themes/custom/apigee_kickstart/src/kits/apigee_custom/apigee_custom.info.yml
+++ b/themes/custom/apigee_kickstart/src/kits/apigee_custom/apigee_custom.info.yml
@@ -1,7 +1,7 @@
 name: RADIX_SUBTHEME_NAME
 description: A sub-theme of Apigee Kickstart.
 screenshot: screenshot.png
-core_version_requirement: ^10
+core_version_requirement: ^10 || ^11
 type: theme
 base theme: apigee_kickstart
 hidden: true


### PR DESCRIPTION
Fixes #712 

Forum - https://www.drupal.org/node/3423968 - D11 support added [here](https://www.drupal.org/project/forum). [1.0.2]
Quickedit - https://www.drupal.org/node/3259831 - No D11 support.
Tour - https://www.drupal.org/node/3421972 - D11 support added [here](https://www.drupal.org/project/tour). [2.0.8]
