### PR TITLE
Menu color specificity added

### DIFF
--- a/themes/custom/apigee_kickstart/src/components/navbar/_navbar.scss
+++ b/themes/custom/apigee_kickstart/src/components/navbar/_navbar.scss
@@ -7,6 +7,14 @@
   font-size: 0.875rem;
   flex-shrink: 0;
 
+  .nav-link.active.is-active {
+    color: var(--ak-header-color);
+  }
+
+  .active .nav-link {
+    color: var(--ak-header-color);
+  }
+
   .nav-link, .nav-link.show {
     color: var(--ak-header-color);
 


### PR DESCRIPTION
Menu css was overrided, by other selector, so specificity is increased in other parts to avoid overriding.
Fixes #752 