### PR TITLE
Add permissions to PHP workflow, added 'justinrainbow/json-schema:^6.5.1' and remove unsupported php and drupal versions.

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -74,6 +74,7 @@ jobs:
     - name: "Allow plugins and dev dependencies"
       run: |
         cd drupal
+        composer require "justinrainbow/json-schema:^6.5.1" --no-update
         composer config --no-plugins allow-plugins.composer/installers true
         composer config --no-plugins allow-plugins.drupal/core-composer-scaffold true
         composer config --no-plugins allow-plugins.drupal/core-project-message true

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -31,14 +31,11 @@ jobs:
       matrix:
         experimental: [false]
         php-version:
-          - "8.1"
           - "8.2"
           - "8.3"
         drupal-core:
           # Should update the following as the minimum supported version from Drupal.org
-          - "10.4.x"
           - "10.5.x"
-          - "11.1.x"
           - "11.2.x"
         exclude:
            - php-version: "8.1"

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -67,7 +67,7 @@ jobs:
         mkdir -p drupal/sites/simpletest/browser_output
   
     - name: Checkout apigee_devportal_kickstart distribution
-      uses: actions/checkout@v3.0.0
+      uses: actions/checkout@v4
       with:
         path: drupal/profiles/contrib/apigee_devportal_kickstart
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -22,7 +22,9 @@ jobs:
   build:
 
     runs-on: ubuntu-24.04
-    
+    permissions:
+      contents: read
+      security-events: write
     name: "PHP ${{ matrix.php-version }} | Drupal ${{ matrix.drupal-core }}"
     strategy:
       fail-fast: false


### PR DESCRIPTION
Closes #769 
This PR has following changes
- Added justinrainbow/json-schema:^6.5.1
- Removed support for PHP 8.1 which reached EOL on 31 Dec 2025
- Removed support for D10.4.x and D11.1.x which reached EOL on 10 Dec 2025
- Updated checkout action version to v4