### PR TITLE
Fix the InvalidArgumentException: A valid cache entry key is required error occurring on the checkout page.

### DIFF
--- a/config/optional/views.view.commerce_cart_block.yml
+++ b/config/optional/views.view.commerce_cart_block.yml
@@ -341,7 +341,7 @@ display:
         order_items:
           id: order_items
           table: commerce_order__order_items
-          field: order_items
+          field: order_items_target_id
           relationship: none
           group_type: group
           admin_label: 'order_items: Order Item'

--- a/config/optional/views.view.commerce_cart_form.yml
+++ b/config/optional/views.view.commerce_cart_form.yml
@@ -412,7 +412,7 @@ display:
         order_items:
           id: order_items
           table: commerce_order__order_items
-          field: order_items
+          field: order_items_target_id
           relationship: none
           group_type: group
           admin_label: 'order_items: Order Item'

--- a/config/optional/views.view.commerce_checkout_order_summary.yml
+++ b/config/optional/views.view.commerce_checkout_order_summary.yml
@@ -313,7 +313,7 @@ display:
         order_items:
           id: order_items
           table: commerce_order__order_items
-          field: order_items
+          field: order_items_target_id
           relationship: none
           group_type: group
           admin_label: 'order_items: Order Item'


### PR DESCRIPTION
Fix: #815

We are putting this PR on hold. The installation error it was meant to fix is no longer appearing, so we need to verify if this change is still necessary.