### PR TITLE
Fix node.body FieldException conflict with Forum module during install

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -88,6 +88,9 @@ jobs:
           jq '.replace += {"drupal/forum": "*", "drupal/tour": "*"}' composer.json > tmp.json && mv tmp.json composer.json
         fi
         
+        # We must prevent the contrib Forum module from trying to download the contrib History module.
+        jq '.replace += {"drupal/history": "*"}' composer.json > tmp.json && mv tmp.json composer.json
+
         composer update --with-all-dependencies
         composer require --dev phpspec/prophecy-phpunit:^2
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -88,9 +88,6 @@ jobs:
           jq '.replace += {"drupal/forum": "*", "drupal/tour": "*"}' composer.json > tmp.json && mv tmp.json composer.json
         fi
         
-        # We must prevent the contrib Forum module from trying to download the contrib History module.
-        jq '.replace += {"drupal/history": "*"}' composer.json > tmp.json && mv tmp.json composer.json
-
         composer update --with-all-dependencies
         composer require --dev phpspec/prophecy-phpunit:^2
 

--- a/apigee_devportal_kickstart.install
+++ b/apigee_devportal_kickstart.install
@@ -301,6 +301,40 @@ function apigee_devportal_kickstart_install() {
 }
 
 /**
+ * Implements hook_module_implements_alter().
+ *
+ * Temporary workaround: The Forum module forcefully alters the 'node.body'
+ * field storage to 'text_long' during node type creation in Drupal 11.4+. This
+ * causes an installation crash because Kickstart relies on 'text_with_summary'.
+ *
+ * To prevent this, we disarm specific Forum module hooks strictly during the
+ * installation phase ($install_state).
+ *
+ * TODO: Remove this workaround when the upstream Drupal core / Forum issue is
+ * resolved and Kickstart updates its body field storage strategy or when
+ * dropping support for Drupal 10.6 and versions prior to 11.3.
+ *
+ * @see https://git.drupalcode.org/project/forum/-/work_items/3584937
+ * @see https://github.com/apigee/apigee-devportal-kickstart-drupal/issues/828
+ * @see https://www.drupal.org/project/drupal/issues/3447617
+ */
+function apigee_devportal_kickstart_module_implements_alter(&$implementations, $hook) {
+  $hooks_to_suppress = [
+    'node_type_insert',
+    'field_config_presave',
+    'field_config_insert'
+  ];
+
+  if (in_array($hook, $hooks_to_suppress) && isset($implementations['forum'])) {
+    global $install_state;
+    // Suppress Forum hooks only while the site installer is actively running.
+    if (!empty($install_state)) {
+      unset($implementations['forum']);
+    }
+  }
+}
+
+/**
  * Implements hook_requirements().
  */
 function apigee_devportal_kickstart_requirements($phase) {


### PR DESCRIPTION
Fix: #828 

The Forum module forcefully alters the node.body field storage to 'text_long' during node type creation in Drupal 11.3+. This causes a FieldException that crashes the Kickstart installation because the distribution's YAML configs rely on 'text_with_summary'.

This commit implements hook_module_implements_alter() to temporarily suppress specific Forum module hooks (node_type_insert, field_config_presave, field_config_insert) while the installer ($install_state) is actively running.

TODO: Remove this workaround when the upstream Drupal core / Forum issue is resolved and Kickstart updates its body 
 
 https://git.drupalcode.org/project/forum/-/work_items/3584937