### PR TITLE
Fix dropbutton links to preserve Ajax modal dialog attributes

### DIFF
--- a/themes/custom/apigee_kickstart/templates/navigation/links--dropbutton.html.twig
+++ b/themes/custom/apigee_kickstart/templates/navigation/links--dropbutton.html.twig
@@ -28,12 +28,7 @@
     {%- for item in links -%}
       <li{{ item.attributes.removeClass('dropdown-item') }}>
         {%- if item.link -%}
-          {% if item.link['#options'].attributes %}
-            {% set link_attributes = create_attribute(item.link['#options'].attributes) %}
-          {% else %}
-            {% set link_attributes = create_attribute() %}
-          {% endif %}
-          <a{{ link_attributes.removeClass('dropdown-item') }} href="{{ item.link['#url'].toString }}">{{- item.link['#title'] -}}</a>
+          {{ item.link }}
         {%- elseif item.text_attributes -%}
           <span{{ item.text_attributes }}>{{ item.text }}</span>
         {%- else -%}


### PR DESCRIPTION
issues/446862467

Render dropbutton links using Drupal standard item.link in links--dropbutton.html.twig instead of manual <a> tag construction. This ensures attributes such as class="use-ajax" and data-dialog-type="modal" are properly rendered, allowing modals like "Add credit" to trigger correctly.

TAG=agy
CONV=34faaf3c-dfe9-4eac-8c15-3d207a787044